### PR TITLE
enhance(install): improve OpenEBS CR status

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -23,7 +23,7 @@ spec:
         args:
         - --logtostderr
         - --run-as-local
-        - -v=4
+        - -v=5
         - --discovery-interval=40s
         - --cache-flush-interval=240s
         resources:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
-	openebs.io/metac v0.1.1-0.20200122022231-6cec7468b84a
+	openebs.io/metac v0.1.1-0.20200207112147-5bfc4b3f4af9
 )
 
-replace openebs.io/metac => github.com/AmitKumarDas/metac v0.1.1-0.20200122022231-6cec7468b84a
+replace openebs.io/metac => github.com/AmitKumarDas/metac v0.1.1-0.20200207112147-5bfc4b3f4af9

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ contrib.go.opencensus.io/exporter/prometheus v0.1.0 h1:SByaIoWwNgMdPSgl5sMqM2KDE
 contrib.go.opencensus.io/exporter/prometheus v0.1.0/go.mod h1:cGFniUXGZlKRjzOyuZJ6mgB+PgBcCIa79kEKR8YCW+A=
 github.com/AmitKumarDas/metac v0.1.1-0.20200122022231-6cec7468b84a h1:h/i/tRtikgKrcvu8VQoH+4ngP/HJe6fbhlOWLjHlpDk=
 github.com/AmitKumarDas/metac v0.1.1-0.20200122022231-6cec7468b84a/go.mod h1:STMXa98wIYVlmc8GSmPhOjbRJar0gdYxpdyso1vE71g=
+github.com/AmitKumarDas/metac v0.1.1-0.20200207112147-5bfc4b3f4af9 h1:gXauBusTv5CUyEEGtphAIAhFhsXrFo9YWd0ZEJs0Glw=
+github.com/AmitKumarDas/metac v0.1.1-0.20200207112147-5bfc4b3f4af9/go.mod h1:STMXa98wIYVlmc8GSmPhOjbRJar0gdYxpdyso1vE71g=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=

--- a/types/openebs.go
+++ b/types/openebs.go
@@ -332,9 +332,9 @@ type OpenEBSStatus struct {
 type OpenEBSStatusPhase string
 
 const (
-	// OpenEBSStatusPhaseError indicates error in
+	// OpenEBSStatusPhaseFailed indicates error in
 	// OpenEBS
-	OpenEBSStatusPhaseError OpenEBSStatusPhase = "Error"
+	OpenEBSStatusPhaseFailed OpenEBSStatusPhase = "Failed"
 
 	// OpenEBSStatusPhaseOnline indicates
 	// OpenEBS in Online state i.e. no error or warning


### PR DESCRIPTION
This PR introduces OpenEBS CR status.phase as Online and Failed.
Whenever the status.phase is Failed, it is accompanied by
.status.reason also which specifies the reason of the failure
of reconciliation.

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>