### PR TITLE
feat(install): add functionality to install CSPC operator

### DIFF
--- a/controller/openebs/cstor.go
+++ b/controller/openebs/cstor.go
@@ -14,7 +14,18 @@ limitations under the License.
 package openebs
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"mayadata.io/openebs-upgrade/types"
+	"mayadata.io/openebs-upgrade/unstruct"
+)
+
+const (
+	// DefaultCSPCOperatorReplicaCount is the default replica count for
+	// cspc-operatot.
+	DefaultCSPCOperatorReplicaCount int32 = 1
+	// DefaultCVCOperatorReplicaCount is the default replica count for
+	// cvc-operatot.
+	DefaultCVCOperatorReplicaCount int32 = 1
 )
 
 // Set the default values for Cstor if not already given.
@@ -49,6 +60,200 @@ func (p *Planner) setCStorDefaultsIfNotSet() error {
 	}
 	p.ObservedOpenEBS.Spec.CstorConfig.VolumeMgmt.Image = p.ObservedOpenEBS.Spec.ImagePrefix +
 		"cstor-volume-mgmt:" + p.ObservedOpenEBS.Spec.CstorConfig.VolumeMgmt.ImageTag
+
+	// form the cstor-pool-manager image(CSPI_MGMT)
+	if p.ObservedOpenEBS.Spec.CstorConfig.CSPIMgmt.ImageTag == "" {
+		p.ObservedOpenEBS.Spec.CstorConfig.CSPIMgmt.ImageTag = p.ObservedOpenEBS.Spec.Version
+	}
+	p.ObservedOpenEBS.Spec.CstorConfig.CSPIMgmt.Image = p.ObservedOpenEBS.Spec.ImagePrefix +
+		"cstor-pool-manager:" + p.ObservedOpenEBS.Spec.CstorConfig.CSPIMgmt.ImageTag
+
+	// form the cstor-volume-manager image
+	if p.ObservedOpenEBS.Spec.CstorConfig.VolumeManager.ImageTag == "" {
+		p.ObservedOpenEBS.Spec.CstorConfig.VolumeManager.ImageTag = p.ObservedOpenEBS.Spec.Version
+	}
+	p.ObservedOpenEBS.Spec.CstorConfig.VolumeManager.Image = p.ObservedOpenEBS.Spec.ImagePrefix +
+		"cstor-volume-manager:" + p.ObservedOpenEBS.Spec.CstorConfig.VolumeManager.ImageTag
+
+	// set the CSPC operator defaults
+	if p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator == nil {
+		p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator = &types.CSPCOperator{}
+	}
+	if p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator.Enabled == nil {
+		p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator.Enabled = new(bool)
+		*p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator.Enabled = true
+	}
+	if p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator.ImageTag == "" {
+		p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator.ImageTag = p.ObservedOpenEBS.Spec.Version
+	}
+	// form the container image as per the image prefix and image tag.
+	p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator.Image = p.ObservedOpenEBS.Spec.ImagePrefix +
+		"cspc-operator:" + p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator.ImageTag
+	if p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator.Replicas == nil {
+		p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator.Replicas = new(int32)
+		*p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator.Replicas = DefaultCSPCOperatorReplicaCount
+	}
+	// set the CVC operator defaults
+	if p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator == nil {
+		p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator = &types.CVCOperator{}
+	}
+	if p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator.Enabled == nil {
+		p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator.Enabled = new(bool)
+		*p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator.Enabled = true
+	}
+	if p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator.ImageTag == "" {
+		p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator.ImageTag = p.ObservedOpenEBS.Spec.Version
+	}
+	// form the container image as per the image prefix and image tag.
+	p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator.Image = p.ObservedOpenEBS.Spec.ImagePrefix +
+		"cvc-operator:" + p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator.ImageTag
+	if p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator.Replicas == nil {
+		p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator.Replicas = new(int32)
+		*p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator.Replicas = DefaultCVCOperatorReplicaCount
+	}
+	return nil
+}
+
+// updateCSPCOperator updates the CSPC operator manifest as per the reconcile.ObservedOpenEBS values.
+func (p *Planner) updateCSPCOperator(deploy *unstructured.Unstructured) error {
+	// get the containers of the cspc-operator and update the desired fields
+	containers, err := unstruct.GetNestedSliceOrError(deploy, "spec", "template", "spec", "containers")
+	if err != nil {
+		return err
+	}
+	// update the env value of cspc-operator container
+	updateCSPCOperatorEnv := func(env *unstructured.Unstructured) error {
+		envName, _, err := unstructured.NestedString(env.Object, "spec", "name")
+		if err != nil {
+			return err
+		}
+		if envName == "OPENEBS_IO_BASE_DIR" {
+			err = unstructured.SetNestedField(env.Object, p.ObservedOpenEBS.Spec.DefaultStoragePath,
+				"spec", "value")
+		} else if envName == "OPENEBS_IO_CSTOR_POOL_SPARSE_DIR" {
+			err = unstructured.SetNestedField(env.Object,
+				p.ObservedOpenEBS.Spec.DefaultStoragePath+"/sparse", "spec", "value")
+		} else if envName == "OPENEBS_IO_CSPI_MGMT_IMAGE" {
+			err = unstructured.SetNestedField(env.Object,
+				p.ObservedOpenEBS.Spec.CstorConfig.CSPIMgmt.Image, "spec", "value")
+		} else if envName == "OPENEBS_IO_CSTOR_POOL_IMAGE" {
+			err = unstructured.SetNestedField(env.Object,
+				p.ObservedOpenEBS.Spec.CstorConfig.Pool.Image, "spec", "value")
+		} else if envName == "OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE" {
+			err = unstructured.SetNestedField(env.Object,
+				p.ObservedOpenEBS.Spec.Policies.Monitoring.Image, "spec", "value")
+		}
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+	updateContainer := func(obj *unstructured.Unstructured) error {
+		containerName, _, err := unstructured.NestedString(obj.Object, "spec", "name")
+		if err != nil {
+			return err
+		}
+		envs, _, err := unstruct.GetSlice(obj, "spec", "env")
+		if err != nil {
+			return err
+		}
+		// update the envs of cspc-operator container
+		// In order to update envs of other containers, just write an updateEnv
+		// function for specific containers.
+		if containerName == "cspc-operator" {
+			err = unstruct.SliceIterator(envs).ForEachUpdate(updateCSPCOperatorEnv)
+			if err != nil {
+				return err
+			}
+		}
+		err = unstructured.SetNestedSlice(obj.Object, envs, "spec", "env")
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	err = unstruct.SliceIterator(containers).ForEachUpdate(updateContainer)
+	if err != nil {
+		return err
+	}
+	err = unstructured.SetNestedSlice(deploy.Object,
+		containers, "spec", "template", "spec", "containers")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// updateCVCOperator updates the CVC operator manifest as per the reconcile.ObservedOpenEBS values.
+func (p *Planner) updateCVCOperator(deploy *unstructured.Unstructured) error {
+	// get the containers of the cvc-operator and update the desired fields
+	containers, err := unstruct.GetNestedSliceOrError(deploy, "spec", "template", "spec", "containers")
+	if err != nil {
+		return err
+	}
+	// update the env value of cvc-operator container
+	updateCVCOperatorEnv := func(env *unstructured.Unstructured) error {
+		envName, _, err := unstructured.NestedString(env.Object, "spec", "name")
+		if err != nil {
+			return err
+		}
+		if envName == "OPENEBS_IO_BASE_DIR" {
+			err = unstructured.SetNestedField(env.Object, p.ObservedOpenEBS.Spec.DefaultStoragePath,
+				"spec", "value")
+		} else if envName == "OPENEBS_IO_CSTOR_TARGET_DIR" {
+			err = unstructured.SetNestedField(env.Object,
+				p.ObservedOpenEBS.Spec.DefaultStoragePath+"/sparse", "spec", "value")
+		} else if envName == "OPENEBS_IO_CSTOR_TARGET_IMAGE" {
+			err = unstructured.SetNestedField(env.Object,
+				p.ObservedOpenEBS.Spec.CstorConfig.Target.Image, "spec", "value")
+		} else if envName == "OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE" {
+			err = unstructured.SetNestedField(env.Object,
+				p.ObservedOpenEBS.Spec.CstorConfig.VolumeManager.Image, "spec", "value")
+		} else if envName == "OPENEBS_IO_VOLUME_MONITOR_IMAGE" {
+			err = unstructured.SetNestedField(env.Object,
+				p.ObservedOpenEBS.Spec.Policies.Monitoring.Image, "spec", "value")
+		}
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+	updateContainer := func(obj *unstructured.Unstructured) error {
+		containerName, _, err := unstructured.NestedString(obj.Object, "spec", "name")
+		if err != nil {
+			return err
+		}
+		envs, _, err := unstruct.GetSlice(obj, "spec", "env")
+		if err != nil {
+			return err
+		}
+		// update the envs of cvc-operator container
+		// In order to update envs of other containers, just write an updateEnv
+		// function for specific containers.
+		if containerName == "cvc-operator" {
+			err = unstruct.SliceIterator(envs).ForEachUpdate(updateCVCOperatorEnv)
+			if err != nil {
+				return err
+			}
+		}
+		err = unstructured.SetNestedSlice(obj.Object, envs, "spec", "env")
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	err = unstruct.SliceIterator(containers).ForEachUpdate(updateContainer)
+	if err != nil {
+		return err
+	}
+	err = unstructured.SetNestedSlice(deploy.Object,
+		containers, "spec", "template", "spec", "containers")
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/controller/openebs/ndm.go
+++ b/controller/openebs/ndm.go
@@ -34,6 +34,9 @@ var supportedNDMVersionForOpenEBSVersion = map[string]string{
 	types.OpenEBSVersion160: types.NDMVersion046,
 	types.OpenEBSVersion170: types.NDMVersion047,
 	types.OpenEBSVersion180: types.NDMVersion048,
+	// TODO: need to be updated with the actual image of NDM
+	// for version 1.9.0
+	types.OpenEBSVersion190: types.NDMVersion048,
 }
 
 // add/update NDM defaults if not already provided

--- a/controller/openebs/reconciler.go
+++ b/controller/openebs/reconciler.go
@@ -259,6 +259,9 @@ func (p *Planner) getDesiredOpenEBSComponents() ReconcileResponse {
 
 func (p *Planner) init() error {
 	var initFuncs = []func() error{
+		p.getManifests,
+		// TODO: Remove once 1.9.0 images are available
+		p.updateVersionFor190,
 		p.setDefaultImagePullPolicyIfNotSet,
 		p.setDefaultStoragePathIfNotSet,
 		p.setDefaultImagePrefixIfNotSet,
@@ -275,7 +278,6 @@ func (p *Planner) init() error {
 		p.setHelperDefaultsIfNotSet,
 		p.setPoliciesDefaultsIfNotSet,
 		p.setAnalyticsDefaultsIfNotSet,
-		p.getManifests,
 		p.removeDisabledManifests,
 		p.getDesiredManifests,
 	}

--- a/deploy/example.yaml
+++ b/deploy/example.yaml
@@ -4,7 +4,7 @@
 apiVersion: dao.mayadata.io/v1alpha1
 kind: OpenEBS
 metadata:
-  name: install-openebs-1.5
+  name: install-openebs-1.9.0
   # Namespace i.e. the namespace where the openebs-upgrade operator and the
   # other openebs components will be installed/needs-to-be-installed.
   namespace: openebs
@@ -12,7 +12,7 @@ metadata:
     name: openebs-upgrade
 spec:
   # OpenEBS Version to be installed.
-  version: "1.5"
+  version: "1.9.0"
 
   # defaultStoragePath is the directory which will be used by
   # default for various OpenEBS operations i.e.,it can be used to
@@ -291,6 +291,43 @@ spec:
       imageTag:
     volumeMgmt:
       imageTag:
+    # Below fields have been introduced from 1.9.0 version onwards in order to support
+    # installation of cStor data engine operators and the related components which will help
+    # in cStor pool provisioning.
+    # CstorPoolCluster(CSPC), CstorPoolInstance(CSPI), CSPC-operator are the new schema
+    # introduced for cStor pool provisioning.
+    #
+    # Note: All the fields introduced below are completely optional i.e., if user
+    # doesn't add any of them, all the CSPC related components will be installed with
+    # default values.
+    cspiMgmt:
+      # example image for cspiMgmt -> "quay.io/openebs/cstor-pool-manager:1.9.0"
+      # this field should only contain the image tag, for example, 1.9.0
+      imageTag:
+    volumeManager:
+      # example image for volumeManager -> "quay.io/openebs/cstor-volume-manager:1.9.0"
+      # this field should only contain the image tag, for example, 1.9.0
+      imageTag:
+    cspcOperator:
+      enabled:
+      # example image for cspc-operator -> "quay.io/openebs/cspc-operator:1.9.0"
+      # this field should only contain the image tag, for example, 1.9.0
+      imageTag:
+      replicas:
+      resources:
+      nodeSelector:
+      tolerations:
+      affinity:
+    cvcOperator:
+      enabled:
+      # example image for cspc-operator -> "quay.io/openebs/cvc-operator:1.9.0"
+      # this field should only contain the image tag, for example, 1.9.0
+      imageTag:
+      replicas:
+      resources:
+      nodeSelector:
+      tolerations:
+      affinity:
 
   # admissionServer is an implementation of kubernetes validation admission webhook.
   #

--- a/templates/openebs-operator-1.9.0.yaml
+++ b/templates/openebs-operator-1.9.0.yaml
@@ -1,0 +1,921 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-maya-operator
+  namespace: openebs
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-maya-operator
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes", "nodes/proxy"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["namespaces", "services", "pods", "pods/exec", "deployments", "deployments/finalizers", "replicationcontrollers", "replicasets", "events", "endpoints", "configmaps", "secrets", "jobs", "cronjobs"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["statefulsets", "daemonsets"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["resourcequotas", "limitranges"]
+  verbs: ["list", "watch"]
+- apiGroups: ["*"]
+  resources: ["ingresses", "horizontalpodautoscalers", "verticalpodautoscalers", "certificatesigningrequests"]
+  verbs: ["list", "watch"]
+- apiGroups: ["*"]
+  resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]
+  verbs: ["*"]
+- apiGroups: ["volumesnapshot.external-storage.k8s.io"]
+  resources: ["volumesnapshots", "volumesnapshotdatas"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: [ "get", "list", "create", "update", "delete", "patch"]
+- apiGroups: ["*"]
+  resources: [ "disks", "blockdevices", "blockdeviceclaims"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: [ "cstorpoolclusters", "storagepoolclaims", "storagepoolclaims/finalizers", "cstorpoolclusters/finalizers", "storagepools"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: [ "castemplates", "runtasks"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: [ "cstorpools", "cstorpools/finalizers", "cstorvolumereplicas", "cstorvolumes", "cstorvolumeclaims", "cstorvolumepolicies"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: [ "cstorpoolinstances", "cstorpoolinstances/finalizers"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: [ "cstorbackups", "cstorrestores", "cstorcompletedbackups"]
+  verbs: ["*" ]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+  verbs: ["get", "create", "list", "delete", "update", "patch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+- apiGroups: ["*"]
+  resources: ["upgradetasks"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["get", "list", "create", "delete", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-maya-operator
+subjects:
+- kind: ServiceAccount
+  name: openebs-maya-operator
+  namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-maya-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maya-apiserver
+  namespace: openebs
+  labels:
+    name: maya-apiserver
+    openebs.io/component-name: maya-apiserver
+    openebs.io/version: 1.8.0
+spec:
+  selector:
+    matchLabels:
+      name: maya-apiserver
+      openebs.io/component-name: maya-apiserver
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        name: maya-apiserver
+        openebs.io/component-name: maya-apiserver
+        openebs.io/version: 1.8.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: maya-apiserver
+        imagePullPolicy: IfNotPresent
+        image: quay.io/openebs/m-apiserver:1.8.0
+        ports:
+        - containerPort: 5656
+        env:
+        - name: OPENEBS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPENEBS_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: OPENEBS_MAYA_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+          value: "true"
+        - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
+          value: "false"
+        - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
+          value: "quay.io/openebs/jiva:1.8.0"
+        - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
+          value: "quay.io/openebs/jiva:1.8.0"
+        - name: OPENEBS_IO_JIVA_REPLICA_COUNT
+          value: "3"
+        - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
+          value: "quay.io/openebs/cstor-istgt:1.8.0"
+        - name: OPENEBS_IO_CSTOR_POOL_IMAGE
+          value: "quay.io/openebs/cstor-pool:1.8.0"
+        - name: OPENEBS_IO_CSTOR_POOL_MGMT_IMAGE
+          value: "quay.io/openebs/cstor-pool-mgmt:1.8.0"
+        - name: OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
+          value: "quay.io/openebs/cstor-volume-mgmt:1.8.0"
+        - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
+          value: "quay.io/openebs/m-exporter:1.8.0"
+        - name: OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
+          value: "quay.io/openebs/m-exporter:1.8.0"
+        - name: OPENEBS_IO_ENABLE_ANALYTICS
+          value: "true"
+        - name: OPENEBS_IO_INSTALLER_TYPE
+          value: "openebs-operator"
+        livenessProbe:
+          exec:
+            command:
+            - /usr/local/bin/mayactl
+            - version
+          initialDelaySeconds: 30
+          periodSeconds: 60
+        readinessProbe:
+          exec:
+            command:
+            - /usr/local/bin/mayactl
+            - version
+          initialDelaySeconds: 30
+          periodSeconds: 60
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: maya-apiserver-service
+  namespace: openebs
+  labels:
+    openebs.io/component-name: maya-apiserver-svc
+spec:
+  ports:
+  - name: api
+    port: 5656
+    protocol: TCP
+    targetPort: 5656
+  selector:
+    name: maya-apiserver
+  sessionAffinity: None
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-provisioner
+  namespace: openebs
+  labels:
+    name: openebs-provisioner
+    openebs.io/component-name: openebs-provisioner
+    openebs.io/version: 1.8.0
+spec:
+  selector:
+    matchLabels:
+      name: openebs-provisioner
+      openebs.io/component-name: openebs-provisioner
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        name: openebs-provisioner
+        openebs.io/component-name: openebs-provisioner
+        openebs.io/version: 1.8.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: openebs-provisioner
+        imagePullPolicy: IfNotPresent
+        image: quay.io/openebs/openebs-k8s-provisioner:1.8.0
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: OPENEBS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        livenessProbe:
+          exec:
+            command:
+            - pgrep
+            - ".*openebs"
+          initialDelaySeconds: 30
+          periodSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-snapshot-operator
+  namespace: openebs
+  labels:
+    name: openebs-snapshot-operator
+    openebs.io/component-name: openebs-snapshot-operator
+    openebs.io/version: 1.8.0
+spec:
+  selector:
+    matchLabels:
+      name: openebs-snapshot-operator
+      openebs.io/component-name: openebs-snapshot-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: openebs-snapshot-operator
+        openebs.io/component-name: openebs-snapshot-operator
+        openebs.io/version: 1.8.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: snapshot-controller
+          image: quay.io/openebs/snapshot-controller:1.8.0
+          imagePullPolicy: IfNotPresent
+          env:
+          - name: OPENEBS_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          livenessProbe:
+            exec:
+              command:
+              - pgrep
+              - ".*controller"
+            initialDelaySeconds: 30
+            periodSeconds: 60
+        - name: snapshot-provisioner
+          image: quay.io/openebs/snapshot-provisioner:1.8.0
+          imagePullPolicy: IfNotPresent
+          env:
+          - name: OPENEBS_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          livenessProbe:
+            exec:
+              command:
+              - pgrep
+              - ".*provisioner"
+            initialDelaySeconds: 30
+            periodSeconds: 60
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openebs-ndm-config
+  namespace: openebs
+  labels:
+    openebs.io/component-name: ndm-config
+data:
+  node-disk-manager.config: |
+    probeconfigs:
+      - key: udev-probe
+        name: udev probe
+        state: true
+      - key: seachest-probe
+        name: seachest probe
+        state: false
+      - key: smart-probe
+        name: smart probe
+        state: true
+    filterconfigs:
+      - key: os-disk-exclude-filter
+        name: os disk exclude filter
+        state: true
+        exclude: "/,/etc/hosts,/boot"
+      - key: vendor-filter
+        name: vendor filter
+        state: true
+        include: ""
+        exclude: "CLOUDBYT,OpenEBS"
+      - key: path-filter
+        name: path filter
+        state: true
+        include: ""
+        exclude: "loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: openebs-ndm
+  namespace: openebs
+  labels:
+    name: openebs-ndm
+    openebs.io/component-name: ndm
+    openebs.io/version: 1.8.0
+spec:
+  selector:
+    matchLabels:
+      name: openebs-ndm
+      openebs.io/component-name: ndm
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: openebs-ndm
+        openebs.io/component-name: ndm
+        openebs.io/version: 1.8.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      hostNetwork: true
+      containers:
+      - name: node-disk-manager
+        image: quay.io/openebs/node-disk-manager-amd64:v0.4.8
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: config
+          mountPath: /host/node-disk-manager.config
+          subPath: node-disk-manager.config
+          readOnly: true
+        - name: udev
+          mountPath: /run/udev
+        - name: procmount
+          mountPath: /host/proc
+          readOnly: true
+        - name: basepath
+          mountPath: /var/openebs/ndm
+        - name: sparsepath
+          mountPath: /var/openebs/sparse
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: SPARSE_FILE_DIR
+          value: "/var/openebs/sparse"
+        - name: SPARSE_FILE_SIZE
+          value: "10737418240"
+        - name: SPARSE_FILE_COUNT
+          value: "0"
+        livenessProbe:
+          exec:
+            command:
+            - pgrep
+            - ".*ndm"
+          initialDelaySeconds: 30
+          periodSeconds: 60
+      volumes:
+      - name: config
+        configMap:
+          name: openebs-ndm-config
+      - name: udev
+        hostPath:
+          path: /run/udev
+          type: Directory
+      - name: procmount
+        hostPath:
+          path: /proc
+          type: Directory
+      - name: basepath
+        hostPath:
+          path: /var/openebs/ndm
+          type: DirectoryOrCreate
+      - name: sparsepath
+        hostPath:
+          path: /var/openebs/sparse
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-ndm-operator
+  namespace: openebs
+  labels:
+    name: openebs-ndm-operator
+    openebs.io/component-name: ndm-operator
+    openebs.io/version: 1.8.0
+spec:
+  selector:
+    matchLabels:
+      name: openebs-ndm-operator
+      openebs.io/component-name: ndm-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: openebs-ndm-operator
+        openebs.io/component-name: ndm-operator
+        openebs.io/version: 1.8.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: node-disk-operator
+          image: quay.io/openebs/node-disk-operator-amd64:v0.4.8
+          imagePullPolicy: Always
+          readinessProbe:
+            exec:
+              command:
+                - stat
+                - /tmp/operator-sdk-ready
+            initialDelaySeconds: 4
+            periodSeconds: 10
+            failureThreshold: 1
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: OPERATOR_NAME
+              value: "node-disk-operator"
+            - name: CLEANUP_JOB_IMAGE
+              value: "quay.io/openebs/linux-utils:1.8.0"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-admission-server
+  namespace: openebs
+  labels:
+    app: admission-webhook
+    openebs.io/component-name: admission-webhook
+    openebs.io/version: 1.8.0
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  selector:
+    matchLabels:
+      app: admission-webhook
+  template:
+    metadata:
+      labels:
+        app: admission-webhook
+        openebs.io/component-name: admission-webhook
+        openebs.io/version: 1.8.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: admission-webhook
+          image: quay.io/openebs/admission-server:1.8.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - -alsologtostderr
+            - -v=2
+            - 2>&1
+          env:
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ADMISSION_WEBHOOK_NAME
+              value: "openebs-admission-server"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-localpv-provisioner
+  namespace: openebs
+  labels:
+    name: openebs-localpv-provisioner
+    openebs.io/component-name: openebs-localpv-provisioner
+    openebs.io/version: 1.8.0
+spec:
+  selector:
+    matchLabels:
+      name: openebs-localpv-provisioner
+      openebs.io/component-name: openebs-localpv-provisioner
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: openebs-localpv-provisioner
+        openebs.io/component-name: openebs-localpv-provisioner
+        openebs.io/version: 1.8.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: openebs-provisioner-hostpath
+        imagePullPolicy: Always
+        image: quay.io/openebs/provisioner-localpv:1.8.0
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: OPENEBS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPENEBS_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: OPENEBS_IO_ENABLE_ANALYTICS
+          value: "true"
+        - name: OPENEBS_IO_INSTALLER_TYPE
+          value: "openebs-operator"
+        - name: OPENEBS_IO_HELPER_IMAGE
+          value: "quay.io/openebs/linux-utils:1.8.0"
+        livenessProbe:
+          exec:
+            command:
+            - pgrep
+            - ".*localpv"
+          initialDelaySeconds: 30
+          periodSeconds: 60
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-cstor-operator
+  namespace: openebs
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-operator
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes", "nodes/proxy"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["namespaces", "services", "pods", "deployments", "deployments/finalizers", "replicationcontrollers", "replicasets", "events", "endpoints", "configmaps", "secrets", "jobs", "cronjobs"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["statefulsets", "daemonsets"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["resourcequotas", "limitranges"]
+  verbs: ["list", "watch"]
+- apiGroups: ["*"]
+  resources: ["certificatesigningrequests"]
+  verbs: ["list", "watch"]
+- apiGroups: ["*"]
+  resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: [ "get", "list", "create", "update", "delete", "patch"]
+- apiGroups: ["*"]
+  resources: ["disks", "blockdevices", "blockdeviceclaims"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: ["cstorpoolclusters", "cstorpoolclusters/finalizers"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: [ "castemplates", "runtasks"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: ["cstorvolumereplicas", "cstorvolumes", "cstorvolumeconfigs", "cstorvolumepolicies"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: ["cstorpoolinstances", "cstorpoolinstances/finalizers"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: ["cstorbackups", "cstorrestores", "cstorcompletedbackups"]
+  verbs: ["*" ]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+  verbs: ["get", "create", "list", "delete", "update", "patch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+- apiGroups: ["*"]
+  resources: ["upgradetasks"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["get", "list", "create", "delete", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-operator
+subjects:
+- kind: ServiceAccount
+  name: openebs-cstor-operator
+  namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorpoolclusters.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: cstorpoolclusters
+    singular: cstorpoolcluster
+    kind: CStorPoolCluster
+    shortNames:
+      - cspc
+  additionalPrinterColumns:
+    - JSONPath: .status.healthyInstances
+      name: HealthyInstances
+      description: The number of healthy cStorPoolInstances
+      type: integer
+    - JSONPath: .status.provisionedInstances
+      name: ProvisionedInstances
+      description: The number of provisioned cStorPoolInstances
+      type: integer
+    - JSONPath: .status.desiredInstances
+      name: DesiredInstances
+      description: The number of desired cStorPoolInstances
+      type: integer
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorpoolinstances.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: cstorpoolinstances
+    singular: cstorpoolinstance
+    kind: CStorPoolInstance
+    shortNames:
+      - cspi
+  additionalPrinterColumns:
+    - JSONPath: .spec.hostName
+      name: HostName
+      description: Host name where cstorpool instances scheduled
+      type: string
+    - JSONPath: .status.capacity.used
+      name: Allocated
+      description: The amount of storage space within the pool that has been physically allocated
+      type: string
+    - JSONPath: .status.capacity.free
+      name: Free
+      description: The amount of free space available in the pool
+      type: string
+    - JSONPath: .status.capacity.total
+      name: Capacity
+      description: Total size of the storage pool
+      type: string
+    - JSONPath: .status.phase
+      name: Status
+      description: Identifies the current health of the pool
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorvolumes.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  version: v1
+  scope: Namespaced
+  names:
+    kind: CStorVolume
+    plural: cstorvolumes
+    singular: cstorvolume
+    shortNames:
+    - cstorvolume
+    - cv
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    name: Status
+    description: Identifies the current health of the volume
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.capacity
+    description: Current volume capacity
+    name: Capacity
+    type: string
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorvolumeconfigs.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  version: v1
+  scope: Namespaced
+  names:
+    kind: CStorVolumeConfig
+    plural: cstorvolumeconfigs
+    singular: cstorvolumeconfig
+    shortNames:
+    - cstorvolumeconfig
+    - cvc
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    name: Status
+    description: Identifies the volume provisioning status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorvolumepolicies.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  version: v1
+  scope: Namespaced
+  names:
+    kind: CStorVolumePolicy
+    plural: cstorvolumepolicies
+    singular: cstorvolumepolicy
+    shortNames:
+    - cstorvolumepolicies
+    - cvp
+    - policy
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    name: Status
+    description: Identifies the state of policy
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorvolumereplicas.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  version: v1
+  scope: Namespaced
+  names:
+    kind: CStorVolumeReplica
+    plural: cstorvolumereplicas
+    singular: cstorvolumereplica
+    shortNames:
+    - cvr
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity.used
+    name: Used
+    description: The amount of space that is "logically" consumed by this dataset
+    type: string
+  - JSONPath: .status.capacity.total
+    name: Allocated
+    description: The amount of disk space consumed by a dataset and all its descendents
+    type: string
+  - JSONPath: .status.phase
+    name: Status
+    description: Identifies the current state of the replicas
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cspc-operator
+  namespace: openebs
+  labels:
+    name: cspc-operator
+    openebs.io/component-name: cspc-operator
+    openebs.io/version: 1.8.0
+spec:
+  selector:
+    matchLabels:
+      name: cspc-operator
+      openebs.io/component-name: cspc-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: cspc-operator
+        openebs.io/component-name: cspc-operator
+        openebs.io/version: 1.8.0
+    spec:
+      serviceAccountName: openebs-cstor-operator
+      containers:
+      - name: cspc-operator
+        imagePullPolicy: IfNotPresent
+        image: quay.io/openebs/cspc-operator:1.8.0
+        env:
+        - name: OPENEBS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPENEBS_SERVICEACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: CSPC_OPERATOR_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPENEBS_IO_BASE_DIR
+          value: "/var/openebs"
+        - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+          value: "/var/openebs/sparse"
+        - name: OPENEBS_IO_CSPI_MGMT_IMAGE
+          value: "quay.io/openebs/cstor-pool-manager:1.8.0"
+        - name: OPENEBS_IO_CSTOR_POOL_IMAGE
+          value: "quay.io/openebs/cstor-pool:1.8.0"
+        - name:  OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
+          value: "quay.io/m-exporter:1.8.0"
+        - name: RESYNC_INTERVAL
+          value: "30"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cvc-operator
+  namespace: openebs
+  labels:
+    name: cvc-operator
+    openebs.io/component-name: cvc-operator
+    openebs.io/version: 1.8.0
+spec:
+  selector:
+    matchLabels:
+      name: cvc-operator
+      openebs.io/component-name: cvc-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: cvc-operator
+        openebs.io/component-name: cvc-operator
+        openebs.io/version: 1.8.0
+    spec:
+      serviceAccountName: openebs-cstor-operator
+      containers:
+      - name: cvc-operator
+        imagePullPolicy: IfNotPresent
+        image: quay.io/openebs/cvc-operator:1.8.0
+        env:
+        - name: OPENEBS_IO_BASE_DIR
+          value: "/var/openebs"
+        - name: OPENEBS_IO_CSTOR_TARGET_DIR
+          value: "/var/openebs/sparse"
+        - name: OPENEBS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPENEBS_SERVICEACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
+          value: "quay.io/openebs/cstor-istgt:1.8.0"
+        - name:  OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
+          value: "quay.io/openebs/cstor-volume-manager:1.8.0"
+        - name:  OPENEBS_IO_VOLUME_MONITOR_IMAGE
+          value: "quay.io/openebs/m-exporter:1.8.0"

--- a/types/key.go
+++ b/types/key.go
@@ -54,6 +54,8 @@ const (
 	KindService string = "Service"
 	// KindServiceAccount is the k8s kind of service account
 	KindServiceAccount string = "ServiceAccount"
+	// KindCustomResourceDefinition is the k8s kind of CustomResourceDefinition
+	KindCustomResourceDefinition string = "CustomResourceDefinition"
 
 	// MayaAPIServerManifestKey is used to get the manifest of maya-apiserver
 	MayaAPIServerManifestKey string = MayaAPIServerNameKey + "_" + KindDeployment
@@ -74,6 +76,58 @@ const (
 	// AdmissionServerManifestKey is used to get the manifest of admission server
 	AdmissionServerManifestKey string = AdmissionServerNameKey + "_" + KindDeployment
 
+	// CVCOperatorNameKey is the name of cvc-operator deployment.
+	CVCOperatorNameKey = "cvc-operator"
+	// CSPCOperatorNameKey is the name of cspc-operator deployment.
+	CSPCOperatorNameKey = "cspc-operator"
+	// CstorOperatorNameKey is the name of cstor-operator service account,
+	// cluster role, cluster role binding.
+	CstorOperatorNameKey = "openebs-cstor-operator"
+	// CSPCCRDNameKey is the name of CSPC CRD
+	CSPCCRDNameKey = "cstorpoolclusters.cstor.openebs.io"
+	// CSPICRDNameKey is the name of the CSPI CRD
+	CSPICRDNameKey = "cstorpoolinstances.cstor.openebs.io"
+	// CstorVolumesCRDNameKey is the name of the Cstor Volume CRD
+	CstorVolumesCRDNameKey = "cstorvolumes.cstor.openebs.io"
+	// CstorVolumeConfigsCRDNameKey is the name of Cstor Volume Configs CRD
+	CstorVolumeConfigsCRDNameKey = "cstorvolumeconfigs.cstor.openebs.io"
+	// CstorVolumeReplicasNameKey is the name of Cstor Volume Replicas CRD
+	CstorVolumeReplicasNameKey = "cstorvolumereplicas.cstor.openebs.io"
+	// CstorVolumePoliciesNameKey is the name of Cstor Volume Policies CRD
+	CstorVolumePoliciesNameKey = "cstorvolumepolicies.cstor.openebs.io"
+
+	// CstorOperatorServiceAccountManifestKey is used to get the manifest of cstor-operator
+	// service account.
+	CstorOperatorServiceAccountManifestKey string = CstorOperatorNameKey + "_" +
+		KindServiceAccount
+	// CstorOperatorClusterRoleManifestKey  is used to get the manifest of cstor-operator
+	// cluster role.
+	CstorOperatorClusterRoleManifestKey string = CstorOperatorNameKey + "_" + KindClusterRole
+	// CstorOperatorClusterRoleBindingManifestKey is used to get the manifest of cstor-operator
+	// cluster role binding.
+	CstorOperatorClusterRoleBindingManifestKey string = CstorOperatorNameKey + "_" +
+		KindClusterRoleBinding
+	// CVCOperatorManifestKey is used to get the manifest of CVC operator
+	CVCOperatorManifestKey string = CVCOperatorNameKey + "_" + KindDeployment
+	// CSPCOperatorManifestKey is used to get the manifest of CSPC operator
+	CSPCOperatorManifestKey string = CSPCOperatorNameKey + "_" + KindDeployment
+	// CSPCCRDManifestKey is used to get the manifest of CSPC CRD
+	CSPCCRDManifestKey string = CSPCCRDNameKey + "_" + KindCustomResourceDefinition
+	// CSPICRDManifestKey is used to get the manifest of CSPI CRD
+	CSPICRDManifestKey string = CSPICRDNameKey + "_" + KindCustomResourceDefinition
+	// CstorVolumesCRDManifestKey is used to get the manifest of Cstor Volumes CRD
+	CstorVolumesCRDManifestKey string = CstorVolumesCRDNameKey + "_" +
+		KindCustomResourceDefinition
+	// CstorVolumesConfigsCRDManifestKey is used to get the manifest of Cstor Volume Configs CRD
+	CstorVolumesConfigsCRDManifestKey string = CstorVolumeConfigsCRDNameKey + "_" +
+		KindCustomResourceDefinition
+	// CstorVolumesPoliciesCRDManifestKey is used to get the manifest of Cstor Volume Policies CRD
+	CstorVolumesPoliciesCRDManifestKey string = CstorVolumePoliciesNameKey + "_" +
+		KindCustomResourceDefinition
+	// CstorVolumesReplicasCRDManifestKey is used to get the manifest of Cstor Volume Replicas CRD
+	CstorVolumesReplicasCRDManifestKey string = CstorVolumeReplicasNameKey + "_" +
+		KindCustomResourceDefinition
+
 	// OpenEBSVersion150 is the OpenEBS version 1.5.0
 	OpenEBSVersion150 string = "1.5.0"
 	// OpenEBSVersion160 is the OpenEBS version 1.6.0
@@ -82,4 +136,6 @@ const (
 	OpenEBSVersion170 string = "1.7.0"
 	// OpenEBSVersion180 is the OpenEBS version 1.8.0
 	OpenEBSVersion180 string = "1.8.0"
+	// OpenEBSVersion190 is the OpenEBS version 1.9.0
+	OpenEBSVersion190 string = "1.9.0"
 )

--- a/types/openebs.go
+++ b/types/openebs.go
@@ -299,10 +299,28 @@ type JivaConfig struct {
 // pool, poolMgmt, target and volumeMgmt are the containers which are deployed
 // in the k8s cluster.
 type CstorConfig struct {
-	Pool       Container `json:"pool"`
-	PoolMgmt   Container `json:"poolMgmt"`
-	Target     Container `json:"target"`
-	VolumeMgmt Container `json:"volumeMgmt"`
+	Pool          Container     `json:"pool"`
+	PoolMgmt      Container     `json:"poolMgmt"`
+	Target        Container     `json:"target"`
+	VolumeMgmt    Container     `json:"volumeMgmt"`
+	CSPIMgmt      Container     `json:"cspiMgmt"`
+	VolumeManager Container     `json:"volumeManager"`
+	CSPCOperator  *CSPCOperator `json:"cspcOperator"`
+	CVCOperator   *CVCOperator  `json:"cvcOperator"`
+}
+
+// CSPCOperator stores the configuration details of CSPCOperator such as
+// if it should be installed or not, image to be used, etc.
+type CSPCOperator struct {
+	Component `json:",inline"`
+	Container `json:",inline"`
+}
+
+// CVCOperator stores the configuration details of CVCOperator such as
+// if it should be installed or not, image to be used, etc.
+type CVCOperator struct {
+	Component `json:",inline"`
+	Container `json:",inline"`
 }
 
 // Container stores the details of a container


### PR DESCRIPTION
This PR adds the functionality to install cStor operator related CRDs, deployments, service account, cluster role and cluster role binding which will be used for cStor pool provisioning.
 
The new fields that has been introduced the OpenEBS CR yaml for configuring cStor-operators installation are displayed inside cstorConfig:
```yaml
# This configuration is for OpenEBS Installation, ControlPlaneUpgrade
# and unInstallation.
apiVersion: dao.mayadata.io/v1alpha1
kind: OpenEBS
metadata:
  name: install-openebs-1.9.0
  # Namespace i.e. the namespace where the openebs-upgrade operator and the
  # other openebs components will be installed/needs-to-be-installed.
  namespace: openebs
  labels:
    name: openebs-upgrade
spec:
  # OpenEBS Version to be installed.
  version: "1.9.0"

  # cstorConfig stores the configuration for Cstor: CAS Data Engine
  #
  # The primary function of cStor is to serve the iSCSI block storage using
  # the underlying disks in a cloud native way.cStor is a very light weight
  # and feature rich storage engine. It provides enterprise grade features
  # such as synchronous data replication, snapshots, clones, thin provisioning
  # of data, high resiliency of data, etc.
  #
  # It has two main components: cStor pool pods and cStor target pods.
  #
  # pool, poolMgmt, target and volumeMgmt are the containers which are deployed
  # in the k8s cluster.
  cstorConfig:
    pool:
      imageTag:
    poolMgmt:
      imageTag:
    target:
      imageTag:
    volumeMgmt:
      imageTag:
    # NOTE: This PR introduces the below new fields for configuring cStor-operators installation.
    #
    # Below fields have been introduced from 1.9.0 version onwards in order to support
    # installation of cStor data engine operators and the related components which will help
    # in cStor pool provisioning.
    # CstorPoolCluster(CSPC), CstorPoolInstance(CSPI), CSPC-operator are the new schema
    # introduced for cStor pool provisioning.
    #
    # Note: All the fields introduced below are completely optional i.e., if user
    # doesn't add any of them, all the CSPC related components will be installed with
    # default values.
    cspiMgmt:
      # example image for cspiMgmt -> "quay.io/openebs/cstor-pool-manager:1.9.0"
      # this field should only contain the image tag, for example, 1.9.0
      imageTag:
    volumeManager:
      # example image for volumeManager -> "quay.io/openebs/cstor-volume-manager:1.9.0"
      # this field should only contain the image tag, for example, 1.9.0
      imageTag:
    cspcOperator:
      enabled:
      # example image for cspc-operator -> "quay.io/openebs/cspc-operator:1.9.0"
      # this field should only contain the image tag, for example, 1.9.0
      imageTag:
      replicas:
      resources:
      nodeSelector:
      tolerations:
      affinity:
    cvcOperator:
      enabled:
      # example image for cspc-operator -> "quay.io/openebs/cvc-operator:1.9.0"
      # this field should only contain the image tag, for example, 1.9.0
      imageTag:
      replicas:
      resources:
      nodeSelector:
      tolerations:
      affinity:
```

Note: For taking a detailed look at the OpenEBS CR YAML, please take a look at `deploy/example.yaml` file.

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>