### PR TITLE
refactor(CSPC-install): remove extra CRDs getting installed

### DIFF
--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -72,6 +72,15 @@ spec:
       - matchReferenceExpressions:
         - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
           refKey: metadata.uid # match this ann value against watch UID
+  - apiVersion: apiextensions.k8s.io/v1beta1
+    resource: customresourcedefinitions
+    updateStrategy:
+      method: InPlace
+    advancedSelector:
+      selectorTerms:
+      - matchReferenceExpressions:
+        - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
+          refKey: metadata.uid # match this ann value against watch UID
   hooks:
     sync:
       inline:

--- a/controller/openebs/cstor.go
+++ b/controller/openebs/cstor.go
@@ -61,19 +61,12 @@ func (p *Planner) setCStorDefaultsIfNotSet() error {
 	p.ObservedOpenEBS.Spec.CstorConfig.VolumeMgmt.Image = p.ObservedOpenEBS.Spec.ImagePrefix +
 		"cstor-volume-mgmt:" + p.ObservedOpenEBS.Spec.CstorConfig.VolumeMgmt.ImageTag
 
-	// form the cstor-pool-manager image(CSPI_MGMT)
+	// form the cspi-mgmt image(CSPI_MGMT)
 	if p.ObservedOpenEBS.Spec.CstorConfig.CSPIMgmt.ImageTag == "" {
 		p.ObservedOpenEBS.Spec.CstorConfig.CSPIMgmt.ImageTag = p.ObservedOpenEBS.Spec.Version
 	}
 	p.ObservedOpenEBS.Spec.CstorConfig.CSPIMgmt.Image = p.ObservedOpenEBS.Spec.ImagePrefix +
-		"cstor-pool-manager:" + p.ObservedOpenEBS.Spec.CstorConfig.CSPIMgmt.ImageTag
-
-	// form the cstor-volume-manager image
-	if p.ObservedOpenEBS.Spec.CstorConfig.VolumeManager.ImageTag == "" {
-		p.ObservedOpenEBS.Spec.CstorConfig.VolumeManager.ImageTag = p.ObservedOpenEBS.Spec.Version
-	}
-	p.ObservedOpenEBS.Spec.CstorConfig.VolumeManager.Image = p.ObservedOpenEBS.Spec.ImagePrefix +
-		"cstor-volume-manager:" + p.ObservedOpenEBS.Spec.CstorConfig.VolumeManager.ImageTag
+		"cspi-mgmt:" + p.ObservedOpenEBS.Spec.CstorConfig.CSPIMgmt.ImageTag
 
 	// set the CSPC operator defaults
 	if p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator == nil {
@@ -210,7 +203,7 @@ func (p *Planner) updateCVCOperator(deploy *unstructured.Unstructured) error {
 				p.ObservedOpenEBS.Spec.CstorConfig.Target.Image, "spec", "value")
 		} else if envName == "OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE" {
 			err = unstructured.SetNestedField(env.Object,
-				p.ObservedOpenEBS.Spec.CstorConfig.VolumeManager.Image, "spec", "value")
+				p.ObservedOpenEBS.Spec.CstorConfig.VolumeMgmt.Image, "spec", "value")
 		} else if envName == "OPENEBS_IO_VOLUME_MONITOR_IMAGE" {
 			err = unstructured.SetNestedField(env.Object,
 				p.ObservedOpenEBS.Spec.Policies.Monitoring.Image, "spec", "value")

--- a/templates/openebs-operator-1.9.0.yaml
+++ b/templates/openebs-operator-1.9.0.yaml
@@ -560,261 +560,20 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 60
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: openebs-cstor-operator
-  namespace: openebs
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: openebs-cstor-operator
-rules:
-- apiGroups: ["*"]
-  resources: ["nodes", "nodes/proxy"]
-  verbs: ["*"]
-- apiGroups: ["*"]
-  resources: ["namespaces", "services", "pods", "deployments", "deployments/finalizers", "replicationcontrollers", "replicasets", "events", "endpoints", "configmaps", "secrets", "jobs", "cronjobs"]
-  verbs: ["*"]
-- apiGroups: ["*"]
-  resources: ["statefulsets", "daemonsets"]
-  verbs: ["*"]
-- apiGroups: ["*"]
-  resources: ["resourcequotas", "limitranges"]
-  verbs: ["list", "watch"]
-- apiGroups: ["*"]
-  resources: ["certificatesigningrequests"]
-  verbs: ["list", "watch"]
-- apiGroups: ["*"]
-  resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]
-  verbs: ["*"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: [ "get", "list", "create", "update", "delete", "patch"]
-- apiGroups: ["*"]
-  resources: ["disks", "blockdevices", "blockdeviceclaims"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: ["cstorpoolclusters", "cstorpoolclusters/finalizers"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "castemplates", "runtasks"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: ["cstorvolumereplicas", "cstorvolumes", "cstorvolumeconfigs", "cstorvolumepolicies"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: ["cstorpoolinstances", "cstorpoolinstances/finalizers"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: ["cstorbackups", "cstorrestores", "cstorcompletedbackups"]
-  verbs: ["*" ]
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
-  verbs: ["get", "create", "list", "delete", "update", "patch"]
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]
-- apiGroups: ["*"]
-  resources: ["upgradetasks"]
-  verbs: ["*"]
-- apiGroups: ["*"]
-  resources: ["poddisruptionbudgets"]
-  verbs: ["get", "list", "create", "delete", "watch"]
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: openebs-cstor-operator
-subjects:
-- kind: ServiceAccount
-  name: openebs-cstor-operator
-  namespace: openebs
-roleRef:
-  kind: ClusterRole
-  name: openebs-cstor-operator
-  apiGroup: rbac.authorization.k8s.io
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: cstorpoolclusters.cstor.openebs.io
+  name: cstorpoolclusters.openebs.io
 spec:
-  group: cstor.openebs.io
-  version: v1
+  group: openebs.io
+  version: v1alpha1
   scope: Namespaced
   names:
     plural: cstorpoolclusters
     singular: cstorpoolcluster
     kind: CStorPoolCluster
     shortNames:
-      - cspc
-  additionalPrinterColumns:
-    - JSONPath: .status.healthyInstances
-      name: HealthyInstances
-      description: The number of healthy cStorPoolInstances
-      type: integer
-    - JSONPath: .status.provisionedInstances
-      name: ProvisionedInstances
-      description: The number of provisioned cStorPoolInstances
-      type: integer
-    - JSONPath: .status.desiredInstances
-      name: DesiredInstances
-      description: The number of desired cStorPoolInstances
-      type: integer
-    - JSONPath: .metadata.creationTimestamp
-      name: Age
-      type: date
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: cstorpoolinstances.cstor.openebs.io
-spec:
-  group: cstor.openebs.io
-  version: v1
-  scope: Namespaced
-  names:
-    plural: cstorpoolinstances
-    singular: cstorpoolinstance
-    kind: CStorPoolInstance
-    shortNames:
-      - cspi
-  additionalPrinterColumns:
-    - JSONPath: .spec.hostName
-      name: HostName
-      description: Host name where cstorpool instances scheduled
-      type: string
-    - JSONPath: .status.capacity.used
-      name: Allocated
-      description: The amount of storage space within the pool that has been physically allocated
-      type: string
-    - JSONPath: .status.capacity.free
-      name: Free
-      description: The amount of free space available in the pool
-      type: string
-    - JSONPath: .status.capacity.total
-      name: Capacity
-      description: Total size of the storage pool
-      type: string
-    - JSONPath: .status.phase
-      name: Status
-      description: Identifies the current health of the pool
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: Age
-      type: date
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: cstorvolumes.cstor.openebs.io
-spec:
-  group: cstor.openebs.io
-  version: v1
-  scope: Namespaced
-  names:
-    kind: CStorVolume
-    plural: cstorvolumes
-    singular: cstorvolume
-    shortNames:
-    - cstorvolume
-    - cv
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    name: Status
-    description: Identifies the current health of the volume
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-  - JSONPath: .status.capacity
-    description: Current volume capacity
-    name: Capacity
-    type: string
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: cstorvolumeconfigs.cstor.openebs.io
-spec:
-  group: cstor.openebs.io
-  version: v1
-  scope: Namespaced
-  names:
-    kind: CStorVolumeConfig
-    plural: cstorvolumeconfigs
-    singular: cstorvolumeconfig
-    shortNames:
-    - cstorvolumeconfig
-    - cvc
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    name: Status
-    description: Identifies the volume provisioning status
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: cstorvolumepolicies.cstor.openebs.io
-spec:
-  group: cstor.openebs.io
-  version: v1
-  scope: Namespaced
-  names:
-    kind: CStorVolumePolicy
-    plural: cstorvolumepolicies
-    singular: cstorvolumepolicy
-    shortNames:
-    - cstorvolumepolicies
-    - cvp
-    - policy
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    name: Status
-    description: Identifies the state of policy
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: cstorvolumereplicas.cstor.openebs.io
-spec:
-  group: cstor.openebs.io
-  version: v1
-  scope: Namespaced
-  names:
-    kind: CStorVolumeReplica
-    plural: cstorvolumereplicas
-    singular: cstorvolumereplica
-    shortNames:
-    - cvr
-  additionalPrinterColumns:
-  - JSONPath: .status.capacity.used
-    name: Used
-    description: The amount of space that is "logically" consumed by this dataset
-    type: string
-  - JSONPath: .status.capacity.total
-    name: Allocated
-    description: The amount of disk space consumed by a dataset and all its descendents
-    type: string
-  - JSONPath: .status.phase
-    name: Status
-    description: Identifies the current state of the replicas
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
+    - cspc
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -840,20 +599,16 @@ spec:
         openebs.io/component-name: cspc-operator
         openebs.io/version: 1.8.0
     spec:
-      serviceAccountName: openebs-cstor-operator
+      serviceAccountName: openebs-maya-operator
       containers:
       - name: cspc-operator
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         image: quay.io/openebs/cspc-operator:1.8.0
         env:
         - name: OPENEBS_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: OPENEBS_SERVICEACCOUNT_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.serviceAccountName
         - name: CSPC_OPERATOR_POD_NAME
           valueFrom:
             fieldRef:
@@ -863,11 +618,11 @@ spec:
         - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
           value: "/var/openebs/sparse"
         - name: OPENEBS_IO_CSPI_MGMT_IMAGE
-          value: "quay.io/openebs/cstor-pool-manager:1.8.0"
+          value: "quay.io/openebs/cspi-mgmt:1.8.0"
         - name: OPENEBS_IO_CSTOR_POOL_IMAGE
           value: "quay.io/openebs/cstor-pool:1.8.0"
         - name:  OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
-          value: "quay.io/m-exporter:1.8.0"
+          value: "quay.io/openebs/m-exporter:1.8.0"
         - name: RESYNC_INTERVAL
           value: "30"
 ---
@@ -895,7 +650,7 @@ spec:
         openebs.io/component-name: cvc-operator
         openebs.io/version: 1.8.0
     spec:
-      serviceAccountName: openebs-cstor-operator
+      serviceAccountName: openebs-maya-operator
       containers:
       - name: cvc-operator
         imagePullPolicy: IfNotPresent
@@ -909,13 +664,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: OPENEBS_SERVICEACCOUNT_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.serviceAccountName
         - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
           value: "quay.io/openebs/cstor-istgt:1.8.0"
         - name:  OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
-          value: "quay.io/openebs/cstor-volume-manager:1.8.0"
+          value: "quay.io/openebs/cstor-volume-mgmt:1.8.0"
         - name:  OPENEBS_IO_VOLUME_MONITOR_IMAGE
           value: "quay.io/openebs/m-exporter:1.8.0"

--- a/types/key.go
+++ b/types/key.go
@@ -80,53 +80,15 @@ const (
 	CVCOperatorNameKey = "cvc-operator"
 	// CSPCOperatorNameKey is the name of cspc-operator deployment.
 	CSPCOperatorNameKey = "cspc-operator"
-	// CstorOperatorNameKey is the name of cstor-operator service account,
-	// cluster role, cluster role binding.
-	CstorOperatorNameKey = "openebs-cstor-operator"
 	// CSPCCRDNameKey is the name of CSPC CRD
 	CSPCCRDNameKey = "cstorpoolclusters.cstor.openebs.io"
-	// CSPICRDNameKey is the name of the CSPI CRD
-	CSPICRDNameKey = "cstorpoolinstances.cstor.openebs.io"
-	// CstorVolumesCRDNameKey is the name of the Cstor Volume CRD
-	CstorVolumesCRDNameKey = "cstorvolumes.cstor.openebs.io"
-	// CstorVolumeConfigsCRDNameKey is the name of Cstor Volume Configs CRD
-	CstorVolumeConfigsCRDNameKey = "cstorvolumeconfigs.cstor.openebs.io"
-	// CstorVolumeReplicasNameKey is the name of Cstor Volume Replicas CRD
-	CstorVolumeReplicasNameKey = "cstorvolumereplicas.cstor.openebs.io"
-	// CstorVolumePoliciesNameKey is the name of Cstor Volume Policies CRD
-	CstorVolumePoliciesNameKey = "cstorvolumepolicies.cstor.openebs.io"
 
-	// CstorOperatorServiceAccountManifestKey is used to get the manifest of cstor-operator
-	// service account.
-	CstorOperatorServiceAccountManifestKey string = CstorOperatorNameKey + "_" +
-		KindServiceAccount
-	// CstorOperatorClusterRoleManifestKey  is used to get the manifest of cstor-operator
-	// cluster role.
-	CstorOperatorClusterRoleManifestKey string = CstorOperatorNameKey + "_" + KindClusterRole
-	// CstorOperatorClusterRoleBindingManifestKey is used to get the manifest of cstor-operator
-	// cluster role binding.
-	CstorOperatorClusterRoleBindingManifestKey string = CstorOperatorNameKey + "_" +
-		KindClusterRoleBinding
 	// CVCOperatorManifestKey is used to get the manifest of CVC operator
 	CVCOperatorManifestKey string = CVCOperatorNameKey + "_" + KindDeployment
 	// CSPCOperatorManifestKey is used to get the manifest of CSPC operator
 	CSPCOperatorManifestKey string = CSPCOperatorNameKey + "_" + KindDeployment
 	// CSPCCRDManifestKey is used to get the manifest of CSPC CRD
 	CSPCCRDManifestKey string = CSPCCRDNameKey + "_" + KindCustomResourceDefinition
-	// CSPICRDManifestKey is used to get the manifest of CSPI CRD
-	CSPICRDManifestKey string = CSPICRDNameKey + "_" + KindCustomResourceDefinition
-	// CstorVolumesCRDManifestKey is used to get the manifest of Cstor Volumes CRD
-	CstorVolumesCRDManifestKey string = CstorVolumesCRDNameKey + "_" +
-		KindCustomResourceDefinition
-	// CstorVolumesConfigsCRDManifestKey is used to get the manifest of Cstor Volume Configs CRD
-	CstorVolumesConfigsCRDManifestKey string = CstorVolumeConfigsCRDNameKey + "_" +
-		KindCustomResourceDefinition
-	// CstorVolumesPoliciesCRDManifestKey is used to get the manifest of Cstor Volume Policies CRD
-	CstorVolumesPoliciesCRDManifestKey string = CstorVolumePoliciesNameKey + "_" +
-		KindCustomResourceDefinition
-	// CstorVolumesReplicasCRDManifestKey is used to get the manifest of Cstor Volume Replicas CRD
-	CstorVolumesReplicasCRDManifestKey string = CstorVolumeReplicasNameKey + "_" +
-		KindCustomResourceDefinition
 
 	// OpenEBSVersion150 is the OpenEBS version 1.5.0
 	OpenEBSVersion150 string = "1.5.0"

--- a/types/openebs.go
+++ b/types/openebs.go
@@ -299,14 +299,13 @@ type JivaConfig struct {
 // pool, poolMgmt, target and volumeMgmt are the containers which are deployed
 // in the k8s cluster.
 type CstorConfig struct {
-	Pool          Container     `json:"pool"`
-	PoolMgmt      Container     `json:"poolMgmt"`
-	Target        Container     `json:"target"`
-	VolumeMgmt    Container     `json:"volumeMgmt"`
-	CSPIMgmt      Container     `json:"cspiMgmt"`
-	VolumeManager Container     `json:"volumeManager"`
-	CSPCOperator  *CSPCOperator `json:"cspcOperator"`
-	CVCOperator   *CVCOperator  `json:"cvcOperator"`
+	Pool         Container     `json:"pool"`
+	PoolMgmt     Container     `json:"poolMgmt"`
+	Target       Container     `json:"target"`
+	VolumeMgmt   Container     `json:"volumeMgmt"`
+	CSPIMgmt     Container     `json:"cspiMgmt"`
+	CSPCOperator *CSPCOperator `json:"cspcOperator"`
+	CVCOperator  *CVCOperator  `json:"cvcOperator"`
 }
 
 // CSPCOperator stores the configuration details of CSPCOperator such as


### PR DESCRIPTION
This PR is required since:

- Some extra CRDs like CSPI, CVR, etc was being installed along with CSPC which are not required since maya-apiserver handles that.

- CSPC installation was installing its own service account, cluster role, cluster role binding which is not required.

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>