### PR TITLE
enhance(install): Install CSI if kubernetes version is equal or above v1.14.0

### DIFF
--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -101,15 +101,6 @@ spec:
           values: ["cstorpoolclusters.openebs.io", "csinodeinfos.csi.storage.k8s.io", "csivolumes.openebs.io",
                     "volumesnapshotclasses.snapshot.storage.k8s.io", "volumesnapshotcontents.snapshot.storage.k8s.io",
                     "volumesnapshots.snapshot.storage.k8s.io"]
-  - apiVersion: storage.k8s.io/v1beta1
-    resource: csidrivers
-    updateStrategy:
-      method: InPlace
-    advancedSelector:
-      selectorTerms:
-      - matchReferenceExpressions:
-        - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
-          refKey: metadata.uid # match this ann value against watch UID
   hooks:
     sync:
       inline:

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -15,7 +15,6 @@ package openebs
 
 import (
 	"io/ioutil"
-	"mayadata.io/openebs-upgrade/k8s"
 	"regexp"
 	"strconv"
 	"strings"
@@ -596,49 +595,6 @@ func (p *Planner) getDesiredCSIDriver(driver *unstructured.Unstructured) (*unstr
 	)
 
 	return driver, nil
-}
-
-// checkCSISupport checks if csi is supported or not in the current kubernetes cluster, if not it will
-// remove the csi based yaml.
-func (p *Planner) checkCSISupport() error {
-	// get the kubernetes version.
-	k8sVersion, err := k8s.GetK8sVersion()
-	if err != nil {
-		return errors.Errorf("Unable to find kubernetes version, error: %v", err)
-	}
-
-	// compare the kubernetes version with the supported version of csi.
-	comp, err := compareVersion(k8sVersion, types.CSISupportedVersion)
-	if err != nil {
-		return errors.Errorf("Error comparing versions, error: %v", err)
-	}
-
-	// remove the csi yaml if the k8s version is less than supported version and the csi is enabled.
-	if comp < 0 && (*p.ObservedOpenEBS.Spec.CstorConfig.CSI.CSIController.Enabled ||
-		*p.ObservedOpenEBS.Spec.CstorConfig.CSI.CSINode.Enabled) {
-		delete(p.ComponentManifests, types.CSINodeInfoCRDManifestKey)
-		delete(p.ComponentManifests, types.CSIVolumeCRDManifestKey)
-		delete(p.ComponentManifests, types.VolumeSnapshotClassCRDManifestKey)
-		delete(p.ComponentManifests, types.VolumeSnapshotContentCRDManifestKey)
-		delete(p.ComponentManifests, types.VolumeSnapshotCRDManifestKey)
-		delete(p.ComponentManifests, types.CStorCSISnapshottterBindingManifestKey)
-		delete(p.ComponentManifests, types.CStorCSISnapshottterRoleManifestKey)
-		delete(p.ComponentManifests, types.CStorCSIControllerSAManifestKey)
-		delete(p.ComponentManifests, types.CStorCSIProvisionerRoleManifestKey)
-		delete(p.ComponentManifests, types.CStorCSIProvisionerBindingManifestKey)
-		delete(p.ComponentManifests, types.CStorCSIControllerManifestKey)
-		delete(p.ComponentManifests, types.CStorCSIAttacherRoleManifestKey)
-		delete(p.ComponentManifests, types.CStorCSIAttacherBindingManifestKey)
-		delete(p.ComponentManifests, types.CStorCSIClusterRegistrarRoleManifestKey)
-		delete(p.ComponentManifests, types.CStorCSIClusterRegistrarBindingManifestKey)
-		delete(p.ComponentManifests, types.CStorCSIRegistrarRoleManifestKey)
-		delete(p.ComponentManifests, types.CStorCSIRegistrarBindingManifestKey)
-		delete(p.ComponentManifests, types.CStorCSINodeSAManifestKey)
-		delete(p.ComponentManifests, types.CStorCSINodeManifestKey)
-		delete(p.ComponentManifests, types.CStorCSIDriverManifestKey)
-	}
-
-	return nil
 }
 
 // compareVersion compares given version i.e v1 and v2.

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -181,6 +181,7 @@ func (p *Planner) removeDisabledManifests() error {
 		delete(p.ComponentManifests, types.CStorCSIClusterRegistrarBindingManifestKey)
 		delete(p.ComponentManifests, types.CStorCSIRegistrarRoleManifestKey)
 		delete(p.ComponentManifests, types.CStorCSIRegistrarBindingManifestKey)
+		delete(p.ComponentManifests, types.CStorCSINodeSAManifestKey)
 		delete(p.ComponentManifests, types.CStorCSINodeManifestKey)
 		delete(p.ComponentManifests, types.CStorCSIDriverManifestKey)
 	}
@@ -613,8 +614,8 @@ func (p *Planner) checkCSISupport() error {
 	}
 
 	// remove the csi yaml if the k8s version is less than supported version and the csi is enabled.
-	if comp < 0 && *p.ObservedOpenEBS.Spec.CstorConfig.CSI.CSIController.Enabled &&
-		*p.ObservedOpenEBS.Spec.CstorConfig.CSI.CSINode.Enabled {
+	if comp < 0 && (*p.ObservedOpenEBS.Spec.CstorConfig.CSI.CSIController.Enabled ||
+		*p.ObservedOpenEBS.Spec.CstorConfig.CSI.CSINode.Enabled) {
 		delete(p.ComponentManifests, types.CSINodeInfoCRDManifestKey)
 		delete(p.ComponentManifests, types.CSIVolumeCRDManifestKey)
 		delete(p.ComponentManifests, types.VolumeSnapshotClassCRDManifestKey)
@@ -632,6 +633,7 @@ func (p *Planner) checkCSISupport() error {
 		delete(p.ComponentManifests, types.CStorCSIClusterRegistrarBindingManifestKey)
 		delete(p.ComponentManifests, types.CStorCSIRegistrarRoleManifestKey)
 		delete(p.ComponentManifests, types.CStorCSIRegistrarBindingManifestKey)
+		delete(p.ComponentManifests, types.CStorCSINodeSAManifestKey)
 		delete(p.ComponentManifests, types.CStorCSINodeManifestKey)
 		delete(p.ComponentManifests, types.CStorCSIDriverManifestKey)
 	}

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -15,6 +15,9 @@ package openebs
 
 import (
 	"io/ioutil"
+	"mayadata.io/openebs-upgrade/k8s"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -592,4 +595,93 @@ func (p *Planner) getDesiredCSIDriver(driver *unstructured.Unstructured) (*unstr
 	)
 
 	return driver, nil
+}
+
+// checkCSISupport checks if csi is supported or not in the current kubernetes cluster, if not it will
+// remove the csi based yaml.
+func (p *Planner) checkCSISupport() error {
+	// get the kubernetes version.
+	k8sVersion, err := k8s.GetK8sVersion()
+	if err != nil {
+		return errors.Errorf("Unable to find kubernetes version, error: %v", err)
+	}
+
+	// compare the kubernetes version with the supported version of csi.
+	comp, err := compareVersion(k8sVersion, types.CSISupportedVersion)
+	if err != nil {
+		return errors.Errorf("Error comparing versions, error: %v", err)
+	}
+
+	// remove the csi yaml if the k8s version is less than supported version and the csi is enabled.
+	if comp < 0 && *p.ObservedOpenEBS.Spec.CstorConfig.CSI.CSIController.Enabled &&
+		*p.ObservedOpenEBS.Spec.CstorConfig.CSI.CSINode.Enabled {
+		delete(p.ComponentManifests, types.CSINodeInfoCRDManifestKey)
+		delete(p.ComponentManifests, types.CSIVolumeCRDManifestKey)
+		delete(p.ComponentManifests, types.VolumeSnapshotClassCRDManifestKey)
+		delete(p.ComponentManifests, types.VolumeSnapshotContentCRDManifestKey)
+		delete(p.ComponentManifests, types.VolumeSnapshotCRDManifestKey)
+		delete(p.ComponentManifests, types.CStorCSISnapshottterBindingManifestKey)
+		delete(p.ComponentManifests, types.CStorCSISnapshottterRoleManifestKey)
+		delete(p.ComponentManifests, types.CStorCSIControllerSAManifestKey)
+		delete(p.ComponentManifests, types.CStorCSIProvisionerRoleManifestKey)
+		delete(p.ComponentManifests, types.CStorCSIProvisionerBindingManifestKey)
+		delete(p.ComponentManifests, types.CStorCSIControllerManifestKey)
+		delete(p.ComponentManifests, types.CStorCSIAttacherRoleManifestKey)
+		delete(p.ComponentManifests, types.CStorCSIAttacherBindingManifestKey)
+		delete(p.ComponentManifests, types.CStorCSIClusterRegistrarRoleManifestKey)
+		delete(p.ComponentManifests, types.CStorCSIClusterRegistrarBindingManifestKey)
+		delete(p.ComponentManifests, types.CStorCSIRegistrarRoleManifestKey)
+		delete(p.ComponentManifests, types.CStorCSIRegistrarBindingManifestKey)
+		delete(p.ComponentManifests, types.CStorCSINodeManifestKey)
+		delete(p.ComponentManifests, types.CStorCSIDriverManifestKey)
+	}
+
+	return nil
+}
+
+// compareVersion compares given version i.e v1 and v2.
+// It returns -1 if v1 is less than v2, 0 if v1 equal to v2, 1 if v1 is greater than v2.
+// It returns -2 in case of any error with error.
+func compareVersion(v1, v2 string) (int, error) {
+
+	// removes alphabets from the version.
+	reg := regexp.MustCompile("[^\\d.]")
+	v1 = reg.ReplaceAllString(v1, "")
+	v2 = reg.ReplaceAllString(v2, "")
+
+	v1Array := strings.Split(v1, ".")
+	v2Array := strings.Split(v2, ".")
+
+	for i := 0; i < len(v1Array) || i < len(v2Array); i++ {
+		if i < len(v1Array) && i < len(v2Array) {
+			v1, err := strconv.Atoi(v1Array[i])
+			v2, err := strconv.Atoi(v2Array[i])
+			if err != nil {
+				return -2, err
+			}
+			if v1 < v2 {
+				return -1, nil
+			} else if v1 > v2 {
+				return 1, nil
+			}
+		} else if i < len(v1Array) {
+			v1, err := strconv.Atoi(v1Array[i])
+			if err != nil {
+				return -2, err
+			}
+			if v1 != 0 {
+				return 1, nil
+			}
+		} else if i < len(v2Array) {
+			v2, err := strconv.Atoi(v2Array[i])
+			if err != nil {
+				return -2, err
+			}
+			if v2 != 0 {
+				return -1, nil
+			}
+		}
+	}
+
+	return 0, nil
 }

--- a/controller/openebs/reconciler.go
+++ b/controller/openebs/reconciler.go
@@ -276,6 +276,7 @@ func (p *Planner) init() error {
 		p.setPoliciesDefaultsIfNotSet,
 		p.setAnalyticsDefaultsIfNotSet,
 		p.removeDisabledManifests,
+		p.checkCSISupport,
 		p.getDesiredManifests,
 	}
 	for _, fn := range initFuncs {

--- a/controller/openebs/reconciler.go
+++ b/controller/openebs/reconciler.go
@@ -276,7 +276,6 @@ func (p *Planner) init() error {
 		p.setPoliciesDefaultsIfNotSet,
 		p.setAnalyticsDefaultsIfNotSet,
 		p.removeDisabledManifests,
-		p.checkCSISupport,
 		p.getDesiredManifests,
 	}
 	for _, fn := range initFuncs {

--- a/k8s/node.go
+++ b/k8s/node.go
@@ -61,3 +61,13 @@ func GetUbuntuVersion() (float64, error) {
 
 	return version, nil
 }
+
+// GetK8sVersion returns the k8s version.
+func GetK8sVersion() (string, error) {
+	versionInfo, err := Clientset.Discovery().ServerVersion()
+	if err != nil {
+		return "", err
+	}
+
+	return versionInfo.GitVersion, nil
+}

--- a/types/key.go
+++ b/types/key.go
@@ -175,17 +175,9 @@ const (
 	// OSImageSLES15 is the OS Image value of a Node.
 	OSImageSLES15 string = "SUSE Linux Enterprise Server 15"
 
-	// CSIOperatorFilePrefix is the csi operator file path prefix.
-	CSIOperatorFilePrefix string = "/templates/csi-operator-"
-	// CSIOperatorFileSuffix is the csi operator file path suffix.
-	CSIOperatorFileSuffix string = ".yaml"
-	// CSIOperatorSUSE12FileSuffix is the csi operator file for suse 12 path suffix.
-	CSIOperatorSUSE12FileSuffix string = "-sles-12.yaml"
-	// CSIOperatorSUSE15FileSuffix is the csi operator file for suse 15 path suffix.
-	CSIOperatorSUSE15FileSuffix string = "-sles-15.yaml"
-	// CSIOperatorUbuntu1804FileSuffix is the csi operator file for ubuntu 18.04 path suffix.
-	CSIOperatorUbuntu1804FileSuffix string = "-ubuntu-18.04.yaml"
-
 	// NamespaceKubeSystem is the value of kube-system namespace
 	NamespaceKubeSystem string = "kube-system"
+
+	// CSISupportedVersion is the k8s version from where csi is supported.
+	CSISupportedVersion string = "v1.14.0"
 )


### PR DESCRIPTION
- This PR removes CSI configuration from metac config, as openebs-upgrade does not start if csidrivers resource is not present and this happens for kubernetes version below v1.14.0
- This PR removes CSI installation yamls if Kubernetes version is below v1.14.0.

Signed-off-by: Sumit Lalwani <sumit.lalwani97@gmail.com>