### PR TITLE
enhance(install): add openebs-upgrade specific labels to OpenEBS components

### DIFF
--- a/controller/openebs/admissionserver.go
+++ b/controller/openebs/admissionserver.go
@@ -14,6 +14,7 @@ limitations under the License.
 package openebs
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"mayadata.io/openebs-upgrade/types"
 )
 
@@ -47,5 +48,25 @@ func (p *Planner) setAdmissionServerDefaultsIfNotSet() error {
 		p.ObservedOpenEBS.Spec.AdmissionServer.Replicas = new(int32)
 		*p.ObservedOpenEBS.Spec.AdmissionServer.Replicas = DefaultAdmissionServerReplicaCount
 	}
+	return nil
+}
+
+// updateAdmissionServer updates the openebs-admission-server manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateAdmissionServer(deploy *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := deploy.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for openebs-snapshot-operator deploy
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-admission-server
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSDeploymentComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.AdmissionServerNameKey
+	// set the desired labels
+	deploy.SetLabels(desiredLabels)
+
 	return nil
 }

--- a/controller/openebs/admissionserver.go
+++ b/controller/openebs/admissionserver.go
@@ -60,10 +60,7 @@ func (p *Planner) updateAdmissionServer(deploy *unstructured.Unstructured) error
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for openebs-snapshot-operator deploy
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
-	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-admission-server
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSDeploymentComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: openebs-admission-server
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.AdmissionServerNameKey
 	// set the desired labels
 	deploy.SetLabels(desiredLabels)

--- a/controller/openebs/apiserver.go
+++ b/controller/openebs/apiserver.go
@@ -29,6 +29,23 @@ const (
 
 // updateMayaAPIServer updates the MayaAPIServer manifest as per the reconcile.ObservedOpenEBS values.
 func (p *Planner) updateMayaAPIServer(deploy *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := deploy.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for maya-apiserver deploy:
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
+	// 2. openebs-upgrade.dao.mayadata.io/component-group: maya-apiserver
+	// 3. openebs-upgrade.dao.mayadata.io/component-name: maya-apiserver
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSDeploymentComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.OpenEBSMayaAPIServerComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.MayaAPIServerNameKey
+	// set the desired labels
+	deploy.SetLabels(desiredLabels)
+
 	// get the containers of the maya-apiserver and update the desired fields
 	containers, err := unstruct.GetNestedSliceOrError(deploy, "spec", "template", "spec", "containers")
 	if err != nil {
@@ -152,5 +169,28 @@ func (p *Planner) setAPIServerDefaultsIfNotSet() error {
 		p.ObservedOpenEBS.Spec.APIServer.Replicas = new(int32)
 		*p.ObservedOpenEBS.Spec.APIServer.Replicas = DefaultAPIServerReplicaCount
 	}
+	return nil
+}
+
+// updateMayaAPIServerService updates the maya-apiserver-service manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateMayaAPIServerService(svc *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := svc.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for maya-apiserver-service service
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: service
+	// 2. openebs-upgrade.dao.mayadata.io/component-group: maya-apiserver
+	// 3. openebs-upgrade.dao.mayadata.io/component-name: maya-apiserver-service
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSServiceComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.OpenEBSMayaAPIServerComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.MayaAPIServerServiceNameKey
+	// set the desired labels
+	svc.SetLabels(desiredLabels)
+
 	return nil
 }

--- a/controller/openebs/apiserver.go
+++ b/controller/openebs/apiserver.go
@@ -35,11 +35,8 @@ func (p *Planner) updateMayaAPIServer(deploy *unstructured.Unstructured) error {
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for maya-apiserver deploy:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: maya-apiserver
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: maya-apiserver
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSDeploymentComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: maya-apiserver
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: maya-apiserver
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSMayaAPIServerComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.MayaAPIServerNameKey
@@ -181,11 +178,8 @@ func (p *Planner) updateMayaAPIServerService(svc *unstructured.Unstructured) err
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for maya-apiserver-service service
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: service
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: maya-apiserver
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: maya-apiserver-service
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSServiceComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: maya-apiserver
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: maya-apiserver-service
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSMayaAPIServerComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.MayaAPIServerServiceNameKey

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -207,6 +207,19 @@ func (p *Planner) getDesiredManifests() error {
 	var err error
 
 	for key, value := range p.ComponentManifests {
+		// set the common label i.e., openebs-upgrade.dao.mayadata.io/managed: true
+		// here since this label should be present in all the components irrespective
+		// of their k8s kind, however some specific labels could be set per component
+		// such as openebs-upgrade.dao.mayadata.io/component-name: ndm for NDM components,
+		// etc.
+		componentLabels := value.GetLabels()
+		if componentLabels == nil {
+			componentLabels = make(map[string]string, 0)
+		}
+		componentLabels[types.OpenEBSUpgradeDAOManagedLabelKey] =
+			types.OpenEBSUpgradeDAOManagedLabelValue
+		value.SetLabels(componentLabels)
+
 		kind := strings.Split(key, "_")[1]
 		switch kind {
 		case types.KindNamespace:
@@ -270,7 +283,7 @@ func (p *Planner) getDesiredDeployment(deploy *unstructured.Unstructured) (*unst
 		nodeSelector = p.ObservedOpenEBS.Spec.APIServer.NodeSelector
 		tolerations = p.ObservedOpenEBS.Spec.APIServer.Tolerations
 		affinity = p.ObservedOpenEBS.Spec.APIServer.Affinity
-		p.updateMayaAPIServer(deploy)
+		err = p.updateMayaAPIServer(deploy)
 
 	case types.ProvisionerNameKey:
 		replicas = p.ObservedOpenEBS.Spec.Provisioner.Replicas
@@ -279,6 +292,7 @@ func (p *Planner) getDesiredDeployment(deploy *unstructured.Unstructured) (*unst
 		nodeSelector = p.ObservedOpenEBS.Spec.Provisioner.NodeSelector
 		tolerations = p.ObservedOpenEBS.Spec.Provisioner.Tolerations
 		affinity = p.ObservedOpenEBS.Spec.Provisioner.Affinity
+		err = p.updateOpenEBSProvisioner(deploy)
 
 	case types.SnapshotOperatorNameKey:
 		replicas = p.ObservedOpenEBS.Spec.SnapshotOperator.Replicas
@@ -288,6 +302,7 @@ func (p *Planner) getDesiredDeployment(deploy *unstructured.Unstructured) (*unst
 		nodeSelector = p.ObservedOpenEBS.Spec.SnapshotOperator.NodeSelector
 		tolerations = p.ObservedOpenEBS.Spec.SnapshotOperator.Tolerations
 		affinity = p.ObservedOpenEBS.Spec.SnapshotOperator.Affinity
+		err = p.updateSnapshotOperator(deploy)
 
 	case types.NDMOperatorNameKey:
 		replicas = p.ObservedOpenEBS.Spec.NDMOperator.Replicas
@@ -296,7 +311,7 @@ func (p *Planner) getDesiredDeployment(deploy *unstructured.Unstructured) (*unst
 		nodeSelector = p.ObservedOpenEBS.Spec.NDMOperator.NodeSelector
 		tolerations = p.ObservedOpenEBS.Spec.NDMOperator.Tolerations
 		affinity = p.ObservedOpenEBS.Spec.NDMOperator.Affinity
-		p.updateNDMOperator(deploy)
+		err = p.updateNDMOperator(deploy)
 
 	case types.LocalProvisionerNameKey:
 		replicas = p.ObservedOpenEBS.Spec.LocalProvisioner.Replicas
@@ -305,7 +320,7 @@ func (p *Planner) getDesiredDeployment(deploy *unstructured.Unstructured) (*unst
 		nodeSelector = p.ObservedOpenEBS.Spec.LocalProvisioner.NodeSelector
 		tolerations = p.ObservedOpenEBS.Spec.LocalProvisioner.Tolerations
 		affinity = p.ObservedOpenEBS.Spec.LocalProvisioner.Affinity
-		p.updateLocalProvisioner(deploy)
+		err = p.updateLocalProvisioner(deploy)
 
 	case types.AdmissionServerNameKey:
 		replicas = p.ObservedOpenEBS.Spec.AdmissionServer.Replicas
@@ -314,6 +329,7 @@ func (p *Planner) getDesiredDeployment(deploy *unstructured.Unstructured) (*unst
 		nodeSelector = p.ObservedOpenEBS.Spec.AdmissionServer.NodeSelector
 		tolerations = p.ObservedOpenEBS.Spec.AdmissionServer.Tolerations
 		affinity = p.ObservedOpenEBS.Spec.AdmissionServer.Affinity
+		err = p.updateAdmissionServer(deploy)
 
 	case types.CSPCOperatorNameKey:
 		replicas = p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator.Replicas
@@ -322,7 +338,7 @@ func (p *Planner) getDesiredDeployment(deploy *unstructured.Unstructured) (*unst
 		nodeSelector = p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator.NodeSelector
 		tolerations = p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator.Tolerations
 		affinity = p.ObservedOpenEBS.Spec.CstorConfig.CSPCOperator.Affinity
-		p.updateCSPCOperator(deploy)
+		err = p.updateCSPCOperator(deploy)
 
 	case types.CVCOperatorNameKey:
 		replicas = p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator.Replicas
@@ -331,7 +347,10 @@ func (p *Planner) getDesiredDeployment(deploy *unstructured.Unstructured) (*unst
 		nodeSelector = p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator.NodeSelector
 		tolerations = p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator.Tolerations
 		affinity = p.ObservedOpenEBS.Spec.CstorConfig.CVCOperator.Affinity
-		p.updateCVCOperator(deploy)
+		err = p.updateCVCOperator(deploy)
+	}
+	if err != nil {
+		return deploy, err
 	}
 	// update the replica count only if it is greater than 1 since the
 	// default value itself is 1.
@@ -429,10 +448,15 @@ func (p *Planner) getDesiredDeployment(deploy *unstructured.Unstructured) (*unst
 
 // getDesiredConfigmap updates the configmap manifest as per the given configuration.
 func (p *Planner) getDesiredConfigmap(configmap *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	var err error
+
 	configmap.SetNamespace(p.ObservedOpenEBS.Namespace)
 	switch configmap.GetName() {
 	case types.NDMConfigNameKey:
-		p.updateNDMConfig(configmap)
+		err = p.updateNDMConfig(configmap)
+	}
+	if err != nil {
+		return configmap, err
 	}
 	// create annotations that refers to the instance which
 	// triggered creation of this ConfigMap
@@ -446,7 +470,15 @@ func (p *Planner) getDesiredConfigmap(configmap *unstructured.Unstructured) (*un
 
 // getDesiredService updates the service manifest as per the given configuration.
 func (p *Planner) getDesiredService(svc *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	var err error
 	svc.SetNamespace(p.ObservedOpenEBS.Namespace)
+	switch svc.GetName() {
+	case types.MayaAPIServerServiceNameKey:
+		err = p.updateMayaAPIServerService(svc)
+	}
+	if err != nil {
+		return svc, err
+	}
 	// create annotations that refers to the instance which
 	// triggered creation of this Service
 	svc.SetAnnotations(
@@ -459,7 +491,7 @@ func (p *Planner) getDesiredService(svc *unstructured.Unstructured) (*unstructur
 
 // getDesiredDaemonSet updates the daemonset manifest as per the given configuration.
 func (p *Planner) getDesiredDaemonSet(daemon *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-
+	var err error
 	resources := make(map[string]interface{})
 	nodeSelector := make(map[string]string)
 	tolerations := make([]interface{}, 0)
@@ -472,12 +504,12 @@ func (p *Planner) getDesiredDaemonSet(daemon *unstructured.Unstructured) (*unstr
 		nodeSelector = p.ObservedOpenEBS.Spec.NDMDaemon.NodeSelector
 		tolerations = p.ObservedOpenEBS.Spec.NDMDaemon.Tolerations
 		affinity = p.ObservedOpenEBS.Spec.NDMDaemon.Affinity
-		p.updateNDM(daemon)
+		err = p.updateNDM(daemon)
 	case types.CStorCSINodeNameKey:
-		err := p.updateOpenEBSCStorCSINode(daemon)
-		if err != nil {
-			return daemon, err
-		}
+		err = p.updateOpenEBSCStorCSINode(daemon)
+	}
+	if err != nil {
+		return daemon, err
 	}
 	// update the daemonset containers with the images and imagePullPolicy
 	containers, err := unstruct.GetNestedSliceOrError(daemon, "spec", "template", "spec", "containers")
@@ -566,23 +598,25 @@ func (p *Planner) getDesiredStatefulSet(statefulset *unstructured.Unstructured) 
 	return statefulset, nil
 }
 
-// getDesiredCustomResourceDefinition updates the customresourcedefinition manifest as per the given configuration.
-func (p *Planner) getDesiredCustomResourceDefinition(crd *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-
-	// create annotations that refers to the instance which
-	// triggered creation of this CustomResourceDefinition
-	crd.SetAnnotations(
-		map[string]string{
-			types.AnnKeyOpenEBSUID: string(p.ObservedOpenEBS.GetUID()),
-		},
-	)
-
-	return crd, nil
-}
-
 // getDesiredCSIDriver updates the csidrivers manifest as per the given configuration.
 func (p *Planner) getDesiredCSIDriver(driver *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := driver.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for CSIDriver controller:
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: csidriver
+	// 2. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
+	// 3. openebs-upgrade.dao.mayadata.io/component-name: cstor.csi.openebs.io
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.CSIDriverComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.OpenEBSCStorCSIComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] =
+		types.CStorCSIDriverNameKey
+	// set the desired labels
+	driver.SetLabels(desiredLabels)
 	// create annotations that refers to the instance which
 	// triggered creation of this CSIDriver
 	driver.SetAnnotations(

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -606,11 +606,8 @@ func (p *Planner) getDesiredCSIDriver(driver *unstructured.Unstructured) (*unstr
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for CSIDriver controller:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: csidriver
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: cstor.csi.openebs.io
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.CSIDriverComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: cstor.csi.openebs.io
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSCStorCSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =

--- a/controller/openebs/crd.go
+++ b/controller/openebs/crd.go
@@ -57,11 +57,8 @@ func (p *Planner) updateCSINodeInfoCRD(crd *unstructured.Unstructured) error {
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for CSI node info CRD
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: customresourcedefinition
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: csinodeinfos.csi.storage.k8s.io
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSCRDComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: csinodeinfos.csi.storage.k8s.io
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.CSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CSINodeInfoCRDNameKey
@@ -80,11 +77,8 @@ func (p *Planner) updateCSIVolumeCRD(crd *unstructured.Unstructured) error {
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for CSI volume CRD
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: customresourcedefinition
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: csivolumes.openebs.io
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSCRDComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: csivolumes.openebs.io
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.CSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CSIVolumeCRDNameKey
@@ -103,10 +97,7 @@ func (p *Planner) updateVolumeSnapshotCRD(crd *unstructured.Unstructured) error 
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for volume snapshot CRD
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: customresourcedefinition
-	// 2. openebs-upgrade.dao.mayadata.io/component-name: volumesnapshots.snapshot.storage.k8s.io
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSCRDComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: volumesnapshots.snapshot.storage.k8s.io
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.VolumeSnapshotCRDNameKey
 	// set the desired labels
 	crd.SetLabels(desiredLabels)
@@ -123,10 +114,7 @@ func (p *Planner) updateVolumeSnapshotClassCRD(crd *unstructured.Unstructured) e
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for volume snapshot class CRD
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: customresourcedefinition
-	// 2. openebs-upgrade.dao.mayadata.io/component-name: volumesnapshotclasses.snapshot.storage.k8s.io
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSCRDComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: volumesnapshotclasses.snapshot.storage.k8s.io
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.VolumeSnapshotClassCRDNameKey
 	// set the desired labels
 	crd.SetLabels(desiredLabels)
@@ -143,10 +131,7 @@ func (p *Planner) updateVolumeSnapshotContentCRD(crd *unstructured.Unstructured)
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for volume snapshot content CRD
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: customresourcedefinition
-	// 2. openebs-upgrade.dao.mayadata.io/component-name: volumesnapshotcontents.snapshot.storage.k8s.io
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSCRDComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: volumesnapshotcontents.snapshot.storage.k8s.io
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.VolumeSnapshotContentCRDNameKey
 	// set the desired labels
 	crd.SetLabels(desiredLabels)
@@ -162,11 +147,8 @@ func (p *Planner) updateCSPCCRD(crd *unstructured.Unstructured) error {
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for CSPC CRD
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: customresourcedefinition
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: cspc
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: cstorpoolclusters.cstor.openebs.io
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSCRDComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: cspc
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: cstorpoolclusters.cstor.openebs.io
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.CSPCComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CSPCCRDNameKey

--- a/controller/openebs/crd.go
+++ b/controller/openebs/crd.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2020 The MayaData Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openebs
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/openebs-upgrade/types"
+)
+
+// getDesiredCustomResourceDefinition updates the customresourcedefinition manifest as per the given configuration.
+func (p *Planner) getDesiredCustomResourceDefinition(crd *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	var err error
+	switch crd.GetName() {
+	case types.CSPCCRDNameKey:
+		err = p.updateCSPCCRD(crd)
+	case types.CSINodeInfoCRDNameKey:
+		err = p.updateCSINodeInfoCRD(crd)
+	case types.CSIVolumeCRDNameKey:
+		err = p.updateCSIVolumeCRD(crd)
+	case types.VolumeSnapshotCRDNameKey:
+		err = p.updateVolumeSnapshotCRD(crd)
+	case types.VolumeSnapshotClassCRDNameKey:
+		err = p.updateVolumeSnapshotClassCRD(crd)
+	case types.VolumeSnapshotContentCRDNameKey:
+		err = p.updateVolumeSnapshotContentCRD(crd)
+	}
+	if err != nil {
+		return crd, err
+	}
+	// create annotations that refers to the instance which
+	// triggered creation of this CustomResourceDefinition
+	crd.SetAnnotations(
+		map[string]string{
+			types.AnnKeyOpenEBSUID: string(p.ObservedOpenEBS.GetUID()),
+		},
+	)
+	return crd, nil
+}
+
+// updateCSINodeInfoCRD updates the CSI node info CRD manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateCSINodeInfoCRD(crd *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := crd.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for CSI node info CRD
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: customresourcedefinition
+	// 2. openebs-upgrade.dao.mayadata.io/component-group: csi
+	// 3. openebs-upgrade.dao.mayadata.io/component-name: csinodeinfos.csi.storage.k8s.io
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSCRDComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.CSIComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CSINodeInfoCRDNameKey
+	// set the desired labels
+	crd.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateCSIVolumeCRD updates the CSI volume CRD manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateCSIVolumeCRD(crd *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := crd.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for CSI volume CRD
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: customresourcedefinition
+	// 2. openebs-upgrade.dao.mayadata.io/component-group: csi
+	// 3. openebs-upgrade.dao.mayadata.io/component-name: csivolumes.openebs.io
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSCRDComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.CSIComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CSIVolumeCRDNameKey
+	// set the desired labels
+	crd.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateVolumeSnapshotCRD updates the volume snapshot CRD manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateVolumeSnapshotCRD(crd *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := crd.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for volume snapshot CRD
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: customresourcedefinition
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: volumesnapshots.snapshot.storage.k8s.io
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSCRDComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.VolumeSnapshotCRDNameKey
+	// set the desired labels
+	crd.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateVolumeSnapshotClassCRD updates the volume snapshot class CRD manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateVolumeSnapshotClassCRD(crd *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := crd.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for volume snapshot class CRD
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: customresourcedefinition
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: volumesnapshotclasses.snapshot.storage.k8s.io
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSCRDComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.VolumeSnapshotClassCRDNameKey
+	// set the desired labels
+	crd.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateVolumeSnapshotContentCRD updates the volume snapshot content CRD manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateVolumeSnapshotContentCRD(crd *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := crd.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for volume snapshot content CRD
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: customresourcedefinition
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: volumesnapshotcontents.snapshot.storage.k8s.io
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSCRDComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.VolumeSnapshotContentCRDNameKey
+	// set the desired labels
+	crd.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateCSPCCRD updates the CSPC CRD manifest as per the reconcile.ObservedOpenEBS values.
+func (p *Planner) updateCSPCCRD(crd *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := crd.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for CSPC CRD
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: customresourcedefinition
+	// 2. openebs-upgrade.dao.mayadata.io/component-group: cspc
+	// 3. openebs-upgrade.dao.mayadata.io/component-name: cstorpoolclusters.cstor.openebs.io
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSCRDComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.CSPCComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CSPCCRDNameKey
+	// set the desired labels
+	crd.SetLabels(desiredLabels)
+
+	return nil
+}

--- a/controller/openebs/cstor.go
+++ b/controller/openebs/cstor.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	// ContainerOpenEBSCSIPlugin is the name of the container openebs csi plugin
+	// ContainerOpenEBSCSIPluginName is the name of the container openebs csi plugin
 	ContainerOpenEBSCSIPluginName string = "openebs-csi-plugin"
 	// EnvOpenEBSNamespaceKey is the env key for openebs namespace
 	EnvOpenEBSNamespaceKey string = "OPENEBS_NAMESPACE"
@@ -162,11 +162,8 @@ func (p *Planner) updateOpenEBSCStorCSINode(daemonset *unstructured.Unstructured
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for CStor CSI Node:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: daemonset
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-node
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSDaemonSetComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-node
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSCStorCSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CStorCSINodeNameKey
@@ -448,11 +445,8 @@ func (p *Planner) updateOpenEBSCStorCSIController(statefulset *unstructured.Unst
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for CStor CSI controller:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: statefulset
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-controller
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSStatefulSetComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-controller
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSCStorCSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
@@ -531,11 +525,8 @@ func (p *Planner) updateCSPCOperator(deploy *unstructured.Unstructured) error {
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for cspc-operator deploy
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: cspc
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: cspc-operator
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSDeploymentComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: cspc
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: cspc-operator
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.CSPCComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CSPCOperatorNameKey
@@ -620,11 +611,8 @@ func (p *Planner) updateCVCOperator(deploy *unstructured.Unstructured) error {
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for cvc-operator deploy
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: cvc
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: cvc-operator
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSDeploymentComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: cvc
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: cvc-operator
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.CVCComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CVCOperatorNameKey

--- a/controller/openebs/cstor.go
+++ b/controller/openebs/cstor.go
@@ -156,6 +156,23 @@ func (p *Planner) updateOpenEBSCStorCSINode(daemonset *unstructured.Unstructured
 	// overwrite the namespace to kube-system as csi based components will run only in kube-system namespace.
 	daemonset.SetNamespace(types.NamespaceKubeSystem)
 
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := daemonset.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for CStor CSI Node:
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: daemonset
+	// 2. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
+	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-node
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSDaemonSetComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.OpenEBSCStorCSIComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CStorCSINodeNameKey
+	// set the desired labels
+	daemonset.SetLabels(desiredLabels)
+
 	// this will get the extra volumes and volume mounts required to be added in the csi node daemonset
 	// for the csi to work for different OS distributions/versions.
 	// This volumes and volume mounts will be added in the openebs-csi-plugin container.
@@ -425,6 +442,23 @@ func (p *Planner) getUbuntu1804VolumeMounts() ([]interface{}, []interface{}) {
 func (p *Planner) updateOpenEBSCStorCSIController(statefulset *unstructured.Unstructured) error {
 	// overwrite the namespace to kube-system as csi based components will run only in kube-system namespace.
 	statefulset.SetNamespace(types.NamespaceKubeSystem)
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := statefulset.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for CStor CSI controller:
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: statefulset
+	// 2. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
+	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-controller
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSStatefulSetComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.OpenEBSCStorCSIComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] =
+		types.CStorCSIControllerNameKey
+	// set the desired labels
+	statefulset.SetLabels(desiredLabels)
 
 	containers, err := unstruct.GetNestedSliceOrError(statefulset, "spec", "template", "spec", "containers")
 	if err != nil {
@@ -491,6 +525,23 @@ func (p *Planner) updateOpenEBSCStorCSIController(statefulset *unstructured.Unst
 
 // updateCSPCOperator updates the CSPC operator manifest as per the reconcile.ObservedOpenEBS values.
 func (p *Planner) updateCSPCOperator(deploy *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := deploy.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for cspc-operator deploy
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
+	// 2. openebs-upgrade.dao.mayadata.io/component-group: cspc
+	// 3. openebs-upgrade.dao.mayadata.io/component-name: cspc-operator
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSDeploymentComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.CSPCComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CSPCOperatorNameKey
+	// set the desired labels
+	deploy.SetLabels(desiredLabels)
+
 	// get the containers of the cspc-operator and update the desired fields
 	containers, err := unstruct.GetNestedSliceOrError(deploy, "spec", "template", "spec", "containers")
 	if err != nil {
@@ -563,6 +614,23 @@ func (p *Planner) updateCSPCOperator(deploy *unstructured.Unstructured) error {
 
 // updateCVCOperator updates the CVC operator manifest as per the reconcile.ObservedOpenEBS values.
 func (p *Planner) updateCVCOperator(deploy *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := deploy.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for cvc-operator deploy
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
+	// 2. openebs-upgrade.dao.mayadata.io/component-group: cvc
+	// 3. openebs-upgrade.dao.mayadata.io/component-name: cvc-operator
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSDeploymentComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.CVCComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CVCOperatorNameKey
+	// set the desired labels
+	deploy.SetLabels(desiredLabels)
+
 	// get the containers of the cvc-operator and update the desired fields
 	containers, err := unstruct.GetNestedSliceOrError(deploy, "spec", "template", "spec", "containers")
 	if err != nil {

--- a/controller/openebs/localprovisioner.go
+++ b/controller/openebs/localprovisioner.go
@@ -56,10 +56,7 @@ func (p *Planner) updateLocalProvisioner(deploy *unstructured.Unstructured) erro
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for openebs-ndm-operator deploy
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
-	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-localpv-provisioner
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSDeploymentComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: openebs-localpv-provisioner
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.LocalProvisionerNameKey
 	// set the desired labels
 	deploy.SetLabels(desiredLabels)

--- a/controller/openebs/localprovisioner.go
+++ b/controller/openebs/localprovisioner.go
@@ -50,6 +50,20 @@ func (p *Planner) setLocalProvisionerDefaultsIfNotSet() error {
 // updateLocalProvisioner updates the localProvisioner structure as per the provided
 // values otherwise default values.
 func (p *Planner) updateLocalProvisioner(deploy *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := deploy.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for openebs-ndm-operator deploy
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-localpv-provisioner
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSDeploymentComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.LocalProvisionerNameKey
+	// set the desired labels
+	deploy.SetLabels(desiredLabels)
+
 	// update the daemonset containers
 	containers, err := unstruct.GetNestedSliceOrError(deploy, "spec", "template", "spec", "containers")
 	if err != nil {

--- a/controller/openebs/ndm.go
+++ b/controller/openebs/ndm.go
@@ -314,12 +314,49 @@ func (p *Planner) updateNDMConfig(configmap *unstructured.Unstructured) error {
 	dataMap["node-disk-manager.config"] = string(ndmConfigDataString)
 	unstructured.SetNestedMap(configmap.Object, dataMap, "data")
 
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := configmap.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for openebs-ndm-config configmap
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: configmap
+	// 2. openebs-upgrade.dao.mayadata.io/component-group: ndm
+	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-ndm-config
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSConfigMapComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.OpenEBSNDMComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.NDMConfigNameKey
+	// set the desired labels
+	configmap.SetLabels(desiredLabels)
+
 	return nil
 }
 
 // updateNDM updates the NDM structure as per the provided values otherwise
 // default values.
 func (p *Planner) updateNDM(daemonset *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := daemonset.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for openebs-ndm-operator deploy
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: daemonset
+	// 2. openebs-upgrade.dao.mayadata.io/component-group: ndm
+	// 3. openebs-upgrade.dao.mayadata.io/component-subgroup: daemon
+	// 4. openebs-upgrade.dao.mayadata.io/component-name: openebs-ndm
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSDaemonSetComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.OpenEBSNDMComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentSubGroupLabelKey] =
+		types.OpenEBSDaemonComponentSubGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.NDMNameKey
+	// set the desired labels
+	daemonset.SetLabels(desiredLabels)
+
 	volumes, err := unstruct.GetNestedSliceOrError(daemonset, "spec", "template", "spec", "volumes")
 	if err != nil {
 		return err
@@ -447,6 +484,26 @@ func (p *Planner) updateNDM(daemonset *unstructured.Unstructured) error {
 // updateNDMOperator updates the NDM Operator structure as per the provided values otherwise
 // default values.
 func (p *Planner) updateNDMOperator(deploy *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := deploy.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for openebs-ndm-operator deploy
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
+	// 2. openebs-upgrade.dao.mayadata.io/component-group: ndm
+	// 3. openebs-upgrade.dao.mayadata.io/component-subgroup: operator
+	// 4. openebs-upgrade.dao.mayadata.io/component-name: openebs-ndm-operator
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSDeploymentComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.OpenEBSNDMComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentSubGroupLabelKey] =
+		types.OpenEBSOperatorComponentSubGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.NDMOperatorNameKey
+	// set the desired labels
+	deploy.SetLabels(desiredLabels)
+
 	// update the daemonset containers
 	containers, err := unstruct.GetNestedSliceOrError(deploy, "spec", "template", "spec", "containers")
 	if err != nil {

--- a/controller/openebs/ndm.go
+++ b/controller/openebs/ndm.go
@@ -320,11 +320,8 @@ func (p *Planner) updateNDMConfig(configmap *unstructured.Unstructured) error {
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for openebs-ndm-config configmap
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: configmap
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: ndm
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-ndm-config
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSConfigMapComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: ndm
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-ndm-config
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSNDMComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.NDMConfigNameKey
@@ -343,12 +340,9 @@ func (p *Planner) updateNDM(daemonset *unstructured.Unstructured) error {
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for openebs-ndm-operator deploy
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: daemonset
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: ndm
-	// 3. openebs-upgrade.dao.mayadata.io/component-subgroup: daemon
-	// 4. openebs-upgrade.dao.mayadata.io/component-name: openebs-ndm
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSDaemonSetComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: ndm
+	// 2. openebs-upgrade.dao.mayadata.io/component-subgroup: daemon
+	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-ndm
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSNDMComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentSubGroupLabelKey] =
@@ -490,12 +484,9 @@ func (p *Planner) updateNDMOperator(deploy *unstructured.Unstructured) error {
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for openebs-ndm-operator deploy
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: ndm
-	// 3. openebs-upgrade.dao.mayadata.io/component-subgroup: operator
-	// 4. openebs-upgrade.dao.mayadata.io/component-name: openebs-ndm-operator
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSDeploymentComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: ndm
+	// 2. openebs-upgrade.dao.mayadata.io/component-subgroup: operator
+	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-ndm-operator
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSNDMComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentSubGroupLabelKey] =

--- a/controller/openebs/provisioner.go
+++ b/controller/openebs/provisioner.go
@@ -56,10 +56,7 @@ func (p *Planner) updateOpenEBSProvisioner(deploy *unstructured.Unstructured) er
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for openebs-provisioner deploy
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
-	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-provisioner
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSDeploymentComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: openebs-provisioner
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.ProvisionerNameKey
 	// set the desired labels
 	deploy.SetLabels(desiredLabels)

--- a/controller/openebs/provisioner.go
+++ b/controller/openebs/provisioner.go
@@ -14,6 +14,7 @@ limitations under the License.
 package openebs
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"mayadata.io/openebs-upgrade/types"
 )
 
@@ -43,5 +44,25 @@ func (p *Planner) setProvisionerDefaultsIfNotSet() error {
 		p.ObservedOpenEBS.Spec.Provisioner.Replicas = new(int32)
 		*p.ObservedOpenEBS.Spec.Provisioner.Replicas = DefaultProvisionerReplicaCount
 	}
+	return nil
+}
+
+// updateOpenEBSProvisioner updates the openebs-provisioner manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateOpenEBSProvisioner(deploy *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := deploy.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for openebs-provisioner deploy
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-provisioner
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSDeploymentComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.ProvisionerNameKey
+	// set the desired labels
+	deploy.SetLabels(desiredLabels)
+
 	return nil
 }

--- a/controller/openebs/rbac.go
+++ b/controller/openebs/rbac.go
@@ -81,10 +81,7 @@ func (p *Planner) updateOpenEBSServiceAccount(sa *unstructured.Unstructured) err
 	// identify a particular or a set of OpenEBS components.
 	//
 	// Component specific labels for openebs-maya-operator service account:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: openebs-service-account
-	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-maya-operator
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSSAComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: openebs-maya-operator
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
 		types.OpenEBSSAComponentNameLabelValue
 
@@ -107,11 +104,8 @@ func (p *Planner) updateCStorCSIControllerServiceAccount(sa *unstructured.Unstru
 	// identify a particular or a set of OpenEBS components.
 	//
 	// Component specific labels for openebs-maya-operator service account:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: service-account
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: cstor-csi-controller
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSSAComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: cstor-csi-controller
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSCStorCSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
@@ -136,11 +130,8 @@ func (p *Planner) updateCStorCSINodeServiceAccount(sa *unstructured.Unstructured
 	// identify a particular or a set of OpenEBS components.
 	//
 	// Component specific labels for openebs-maya-operator service account:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: service-account
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: cstor-csi-node
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSSAComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: cstor-csi-node
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSCStorCSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
@@ -196,11 +187,7 @@ func (p *Planner) updateOpenEBSClusterRole(sa *unstructured.Unstructured) error 
 	// These labels will be only set by openebs-upgrade and will help the end-users
 	// identify a particular or a set of OpenEBS components.
 	//
-	// Component specific labels for openebs-maya-operator cluster role:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: cluster-role
-	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-maya-operator
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSRoleComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: openebs-maya-operator
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
 		types.OpenEBSRoleComponentNameLabelValue
 
@@ -223,11 +210,8 @@ func (p *Planner) updateCStorCSISnapshotterRole(sa *unstructured.Unstructured) e
 	// identify a particular or a set of OpenEBS components.
 	//
 	// Component specific labels for cstor CSI snapshotter cluster role:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: cluster-role
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-snapshotter-role
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSRoleComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-snapshotter-role
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSCStorCSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
@@ -252,11 +236,8 @@ func (p *Planner) updateCStorCSIProvisionerRole(sa *unstructured.Unstructured) e
 	// identify a particular or a set of OpenEBS components.
 	//
 	// Component specific labels for cstor CSI provisioner cluster role:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: cluster-role
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-provisioner-role
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSRoleComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-provisioner-role
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSCStorCSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
@@ -281,11 +262,8 @@ func (p *Planner) updateCStorCSIAttacherRole(sa *unstructured.Unstructured) erro
 	// identify a particular or a set of OpenEBS components.
 	//
 	// Component specific labels for openebs-cstor-csi-attacher-role cluster role:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: cluster-role
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-attacher-role
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSRoleComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-attacher-role
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSCStorCSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
@@ -310,11 +288,8 @@ func (p *Planner) updateCStorCSIClusterRegistrarRole(sa *unstructured.Unstructur
 	// identify a particular or a set of OpenEBS components.
 	//
 	// Component specific labels for openebs-cstor-csi-cluster-registrar-role cluster role:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: cluster-role
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-cluster-registrar-role
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSRoleComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-cluster-registrar-role
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSCStorCSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
@@ -339,11 +314,8 @@ func (p *Planner) updateCStorCSIRegistrarRole(sa *unstructured.Unstructured) err
 	// identify a particular or a set of OpenEBS components.
 	//
 	// Component specific labels for openebs-cstor-csi-registrar-role cluster role:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: cluster-role
-	// 2. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-registrar-role
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSRoleComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: cstor-csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-registrar-role
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSCStorCSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
@@ -435,10 +407,7 @@ func (p *Planner) updateOpenEBSClusterRoleBinding(sa *unstructured.Unstructured)
 	// identify a particular or a set of OpenEBS components.
 	//
 	// Component specific labels for openebs-maya-operator cluster role binding:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: cluster-role-binding
-	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-maya-operator
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSRoleBindingComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: openebs-maya-operator
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
 		types.OpenEBSRoleBindingComponentNameLabelValue
 
@@ -461,11 +430,8 @@ func (p *Planner) updateCStorCSISnapshotterBinding(sa *unstructured.Unstructured
 	// identify a particular or a set of OpenEBS components.
 	//
 	// Component specific labels for openebs-cstor-csi-snapshotter-binding cluster role binding:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: cluster-role-binding
-	// 2. openebs-upgrade.dao.mayadata.io/component-subtype: cstor-csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-snapshotter-binding
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSRoleBindingComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-subtype: cstor-csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-snapshotter-binding
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSCStorCSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
@@ -490,11 +456,8 @@ func (p *Planner) updateCStorCSIProvisionerBinding(sa *unstructured.Unstructured
 	// identify a particular or a set of OpenEBS components.
 	//
 	// Component specific labels for openebs-cstor-csi-provisioner-binding cluster role binding:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: cluster-role-binding
-	// 2. openebs-upgrade.dao.mayadata.io/component-subtype: cstor-csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-provisioner-binding
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSRoleBindingComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-subtype: cstor-csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-provisioner-binding
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSCStorCSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
@@ -519,11 +482,8 @@ func (p *Planner) updateCStorCSIAttacherBinding(sa *unstructured.Unstructured) e
 	// identify a particular or a set of OpenEBS components.
 	//
 	// Component specific labels for openebs-cstor-csi-attacher-binding cluster role binding:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: cluster-role-binding
-	// 2. openebs-upgrade.dao.mayadata.io/component-subtype: cstor-csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-attacher-binding
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSRoleBindingComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-subtype: cstor-csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-attacher-binding
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSCStorCSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
@@ -548,11 +508,8 @@ func (p *Planner) updateCStorCSIClusterRegistrarBinding(sa *unstructured.Unstruc
 	// identify a particular or a set of OpenEBS components.
 	//
 	// Component specific labels for openebs-cstor-csi-cluster-registrar-binding cluster role:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: cluster-role-binding
-	// 2. openebs-upgrade.dao.mayadata.io/component-subtype: cstor-csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-cluster-registrar-binding
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSRoleBindingComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-subtype: cstor-csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-cluster-registrar-binding
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSCStorCSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
@@ -577,11 +534,8 @@ func (p *Planner) updateCStorCSIRegistrarBinding(sa *unstructured.Unstructured) 
 	// identify a particular or a set of OpenEBS components.
 	//
 	// Component specific labels for openebs-cstor-csi-registrar-binding cluster role binding:
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: cluster-role-binding
-	// 2. openebs-upgrade.dao.mayadata.io/component-subtype: cstor-csi
-	// 3. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-registrar-binding
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSRoleBindingComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-subtype: cstor-csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-csi-registrar-binding
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.OpenEBSCStorCSIComponentGroupLabelValue
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =

--- a/controller/openebs/snapshotoperator.go
+++ b/controller/openebs/snapshotoperator.go
@@ -13,7 +13,10 @@ limitations under the License.
 
 package openebs
 
-import "mayadata.io/openebs-upgrade/types"
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/openebs-upgrade/types"
+)
 
 const (
 	// DefaultSnapshotOperatorReplicaCount is the default value of replica for
@@ -49,5 +52,25 @@ func (p *Planner) setSnapshotOperatorDefaultsIfNotSet() error {
 		p.ObservedOpenEBS.Spec.SnapshotOperator.Replicas = new(int32)
 		*p.ObservedOpenEBS.Spec.SnapshotOperator.Replicas = DefaultSnapshotOperatorReplicaCount
 	}
+	return nil
+}
+
+// updateSnapshotOperator updates the openebs-snapshot-operator manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateSnapshotOperator(deploy *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := deploy.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for openebs-snapshot-operator deploy
+	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-snapshot-operator
+	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
+		types.OpenEBSDeploymentComponentTypeLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.SnapshotOperatorNameKey
+	// set the desired labels
+	deploy.SetLabels(desiredLabels)
+
 	return nil
 }

--- a/controller/openebs/snapshotoperator.go
+++ b/controller/openebs/snapshotoperator.go
@@ -64,10 +64,7 @@ func (p *Planner) updateSnapshotOperator(deploy *unstructured.Unstructured) erro
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for openebs-snapshot-operator deploy
-	// 1. openebs-upgrade.dao.mayadata.io/component-type: deployment
-	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-snapshot-operator
-	desiredLabels[types.OpenEBSComponentTypeLabelKey] =
-		types.OpenEBSDeploymentComponentTypeLabelValue
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: openebs-snapshot-operator
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.SnapshotOperatorNameKey
 	// set the desired labels
 	deploy.SetLabels(desiredLabels)

--- a/types/key.go
+++ b/types/key.go
@@ -188,4 +188,121 @@ const (
 
 	// NamespaceKubeSystem is the value of kube-system namespace
 	NamespaceKubeSystem string = "kube-system"
+
+	// OpenEBSMayaOperatorSANameKey is the name of OpenEBS service account.
+	OpenEBSMayaOperatorSANameKey string = "openebs-maya-operator"
+	// OpenEBSMayaOperatorRoleNameKey is the name of OpenEBS cluster role.
+	OpenEBSMayaOperatorRoleNameKey string = "openebs-maya-operator"
+	// OpenEBSMayaOperatorBindingNameKey is the name of OpenEBS cluster role binding.
+	OpenEBSMayaOperatorBindingNameKey string = "openebs-maya-operator"
+
+	// openebs-upgrade dao specific label, this label will be present across all the
+	// OpenEBS components whether created or adopted by openebs-upgrade.
+
+	// OpenEBSUpgradeDAOManagedLabelKey is the key for openebs-upgrade dao managed label
+	OpenEBSUpgradeDAOManagedLabelKey string = "openebs-upgrade.dao.mayadata.io/managed"
+	// OpenEBSUpgradeDAOManagedLabelValue is the value for openebs-upgrade dao managed label
+	OpenEBSUpgradeDAOManagedLabelValue string = "true"
+
+	// OpenEBSComponentTypeLabelKey is the label key which helps in
+	// identifying a particular group of OpenEBS components i.e., the component-type
+	// value for NDM components will be "ndm".
+	OpenEBSComponentTypeLabelKey string = "openebs-upgrade.dao.mayadata.io/component-type"
+	// OpenEBSComponentGroupLabelKey is the label key which helps in identifying
+	// a particular group of OpenEBS components i.e., the component-type value for
+	// CSI related cluster roles can still be "cluster-role" but the value for
+	// component-group can be "csi" which will help in identifying all the
+	// OpenEBS related cluster roles as well as cluster roles specific to CSI also.
+	OpenEBSComponentGroupLabelKey string = "openebs-upgrade.dao.mayadata.io/component-group"
+	// OpenEBSComponentSubGroupLabelKey is the label key which helps in identifying
+	// a particular subgroup of OpenEBS components i.e., the value for
+	// component-group for NDM components can be "ndm" which will help in identifying all the
+	// OpenEBS NDM related components, but it will have a component-subgroup too like
+	// operator or daemon which will tell that this particular NDM components is an operator or
+	// NDM daemon or something else.
+	OpenEBSComponentSubGroupLabelKey string = "openebs-upgrade.dao.mayadata.io/component-subgroup"
+	// OpenEBSComponentNameLabelKey is the label key which helps in
+	// identifying a particular OpenEBS component i.e., openebs-ndm will be the label value
+	// for ndm daemonset while openebs-ndm-operator will be the value for NDM operator.
+	OpenEBSComponentNameLabelKey string = "openebs-upgrade.dao.mayadata.io/component-name"
+
+	// OpenEBSSAComponentTypeLabelValue is the value of the component-type label
+	// of OpenEBS service account.
+	OpenEBSSAComponentTypeLabelValue string = "service-account"
+	// OpenEBSSAComponentNameLabelValue is the value of the component-name label
+	// of OpenEBS service account.
+	OpenEBSSAComponentNameLabelValue string = "openebs-maya-operator"
+	// CStorCSICtrlSAComponentNameLabelValue is the value of the component-name label
+	// of OpenEBS CStor CSI controller service account.
+	CStorCSICtrlSAComponentNameLabelValue string = "cstor-csi-controller"
+	// CStorCSINodeSAComponentNameLabelValue is the value of the component-name label
+	// of OpenEBS CStor CSI node service account.
+	CStorCSINodeSAComponentNameLabelValue string = "cstor-csi-node"
+
+	// OpenEBSRoleComponentTypeLabelValue is the value of the component-type label
+	// of OpenEBS cluster role.
+	OpenEBSRoleComponentTypeLabelValue string = "cluster-role"
+	// CSIComponentGroupLabelValue is the value of the component-group label
+	// of CSI components.
+	CSIComponentGroupLabelValue string = "csi"
+	// OpenEBSCStorCSIComponentGroupLabelValue is the value of the component-group label
+	// of CSI components.
+	OpenEBSCStorCSIComponentGroupLabelValue string = "cstor-csi"
+	// OpenEBSRoleComponentNameLabelValue is the value of the component-name label
+	// of OpenEBS cluster role.
+	OpenEBSRoleComponentNameLabelValue string = "openebs-maya-operator"
+
+	// OpenEBSRoleBindingComponentTypeLabelValue is the value of the component-type label
+	// of OpenEBS cluster role binding.
+	OpenEBSRoleBindingComponentTypeLabelValue string = "cluster-role-binding"
+	// OpenEBSRoleBindingComponentNameLabelValue is the value of the component-name label
+	// of OpenEBS cluster role.
+	OpenEBSRoleBindingComponentNameLabelValue string = "openebs-maya-operator"
+
+	// OpenEBSDeploymentComponentTypeLabelValue is the value of the component-type label
+	// of OpenEBS deployments.
+	OpenEBSDeploymentComponentTypeLabelValue string = "deployment"
+	// OpenEBSDaemonSetComponentTypeLabelValue is the value of the component-type label
+	// of OpenEBS daemonsets.
+	OpenEBSDaemonSetComponentTypeLabelValue string = "daemonset"
+	// OpenEBSStatefulSetComponentTypeLabelValue is the value of the component-type label
+	// of OpenEBS statefulsets.
+	OpenEBSStatefulSetComponentTypeLabelValue string = "statefulset"
+	// CSIDriverComponentTypeLabelValue is the value of the component-type label
+	// of CSI driver.
+	CSIDriverComponentTypeLabelValue string = "csidriver"
+	// OpenEBSCRDComponentTypeLabelValue is the value of the component-type label
+	// of OpenEBS related CRDs.
+	OpenEBSCRDComponentTypeLabelValue string = "customresourcedefinition"
+
+	// OpenEBSMayaAPIServerComponentGroupLabelValue is the value of the component-group label
+	// of OpenEBS apiservers.
+	OpenEBSMayaAPIServerComponentGroupLabelValue string = "maya-apiserver"
+	// OpenEBSProvisionerComponentGroupLabelValue is the value of the component-group label
+	// of OpenEBS provisioner.
+	OpenEBSProvisionerComponentGroupLabelValue string = "openebs-provisioner"
+	// OpenEBSOperatorComponentSubGroupLabelValue is the value of the component-subgroup label
+	// of OpenEBS operators.
+	OpenEBSOperatorComponentSubGroupLabelValue string = "operator"
+	// OpenEBSDaemonComponentSubGroupLabelValue is the value of the component-subgroup label
+	// of OpenEBS daemons.
+	OpenEBSDaemonComponentSubGroupLabelValue string = "daemon"
+	// OpenEBSAdmissionServerComponentGroupLabelValue is the value of the component-group label
+	// of OpenEBS admission server.
+	OpenEBSAdmissionServerComponentGroupLabelValue string = "admission-server"
+	// OpenEBSConfigMapComponentTypeLabelValue is the value of the component-type label
+	// of OpenEBS configmaps.
+	OpenEBSConfigMapComponentTypeLabelValue string = "configmap"
+	// OpenEBSServiceComponentTypeLabelValue is the value of the component-type label
+	// of OpenEBS services.
+	OpenEBSServiceComponentTypeLabelValue string = "service"
+	// OpenEBSNDMComponentGroupLabelValue is the value of the component-group label
+	// of NDM components.
+	OpenEBSNDMComponentGroupLabelValue string = "ndm"
+	// CSPCComponentGroupLabelValue is the value of the component-group label
+	// of CSPC components.
+	CSPCComponentGroupLabelValue string = "cspc"
+	// CVCComponentGroupLabelValue is the value of the component-group label
+	// of CVC components.
+	CVCComponentGroupLabelValue string = "cvc"
 )

--- a/types/key.go
+++ b/types/key.go
@@ -204,10 +204,6 @@ const (
 	// OpenEBSUpgradeDAOManagedLabelValue is the value for openebs-upgrade dao managed label
 	OpenEBSUpgradeDAOManagedLabelValue string = "true"
 
-	// OpenEBSComponentTypeLabelKey is the label key which helps in
-	// identifying a particular group of OpenEBS components i.e., the component-type
-	// value for NDM components will be "ndm".
-	OpenEBSComponentTypeLabelKey string = "openebs-upgrade.dao.mayadata.io/component-type"
 	// OpenEBSComponentGroupLabelKey is the label key which helps in identifying
 	// a particular group of OpenEBS components i.e., the component-type value for
 	// CSI related cluster roles can still be "cluster-role" but the value for
@@ -226,9 +222,6 @@ const (
 	// for ndm daemonset while openebs-ndm-operator will be the value for NDM operator.
 	OpenEBSComponentNameLabelKey string = "openebs-upgrade.dao.mayadata.io/component-name"
 
-	// OpenEBSSAComponentTypeLabelValue is the value of the component-type label
-	// of OpenEBS service account.
-	OpenEBSSAComponentTypeLabelValue string = "service-account"
 	// OpenEBSSAComponentNameLabelValue is the value of the component-name label
 	// of OpenEBS service account.
 	OpenEBSSAComponentNameLabelValue string = "openebs-maya-operator"
@@ -239,9 +232,6 @@ const (
 	// of OpenEBS CStor CSI node service account.
 	CStorCSINodeSAComponentNameLabelValue string = "cstor-csi-node"
 
-	// OpenEBSRoleComponentTypeLabelValue is the value of the component-type label
-	// of OpenEBS cluster role.
-	OpenEBSRoleComponentTypeLabelValue string = "cluster-role"
 	// CSIComponentGroupLabelValue is the value of the component-group label
 	// of CSI components.
 	CSIComponentGroupLabelValue string = "csi"
@@ -252,28 +242,9 @@ const (
 	// of OpenEBS cluster role.
 	OpenEBSRoleComponentNameLabelValue string = "openebs-maya-operator"
 
-	// OpenEBSRoleBindingComponentTypeLabelValue is the value of the component-type label
-	// of OpenEBS cluster role binding.
-	OpenEBSRoleBindingComponentTypeLabelValue string = "cluster-role-binding"
 	// OpenEBSRoleBindingComponentNameLabelValue is the value of the component-name label
 	// of OpenEBS cluster role.
 	OpenEBSRoleBindingComponentNameLabelValue string = "openebs-maya-operator"
-
-	// OpenEBSDeploymentComponentTypeLabelValue is the value of the component-type label
-	// of OpenEBS deployments.
-	OpenEBSDeploymentComponentTypeLabelValue string = "deployment"
-	// OpenEBSDaemonSetComponentTypeLabelValue is the value of the component-type label
-	// of OpenEBS daemonsets.
-	OpenEBSDaemonSetComponentTypeLabelValue string = "daemonset"
-	// OpenEBSStatefulSetComponentTypeLabelValue is the value of the component-type label
-	// of OpenEBS statefulsets.
-	OpenEBSStatefulSetComponentTypeLabelValue string = "statefulset"
-	// CSIDriverComponentTypeLabelValue is the value of the component-type label
-	// of CSI driver.
-	CSIDriverComponentTypeLabelValue string = "csidriver"
-	// OpenEBSCRDComponentTypeLabelValue is the value of the component-type label
-	// of OpenEBS related CRDs.
-	OpenEBSCRDComponentTypeLabelValue string = "customresourcedefinition"
 
 	// OpenEBSMayaAPIServerComponentGroupLabelValue is the value of the component-group label
 	// of OpenEBS apiservers.
@@ -290,12 +261,6 @@ const (
 	// OpenEBSAdmissionServerComponentGroupLabelValue is the value of the component-group label
 	// of OpenEBS admission server.
 	OpenEBSAdmissionServerComponentGroupLabelValue string = "admission-server"
-	// OpenEBSConfigMapComponentTypeLabelValue is the value of the component-type label
-	// of OpenEBS configmaps.
-	OpenEBSConfigMapComponentTypeLabelValue string = "configmap"
-	// OpenEBSServiceComponentTypeLabelValue is the value of the component-type label
-	// of OpenEBS services.
-	OpenEBSServiceComponentTypeLabelValue string = "service"
 	// OpenEBSNDMComponentGroupLabelValue is the value of the component-group label
 	// of NDM components.
 	OpenEBSNDMComponentGroupLabelValue string = "ndm"


### PR DESCRIPTION
This PR intends to achieve the following things:

-  It adds `openebs-upgrade` specific labels to all the OpenEBS components being installed by `openebs-upgrade`.

- It adds dedicated update functions for the components(for those which already didn't had dedicated fn to update their manifest) being installed by OpenEBS in order to update their manifest with labels, annotations, etc.

Some of the examples of the labels that have been added to the various OpenEBS components are:

For NDM components,
```
NAME          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                 AGE   LABELS
openebs-ndm   4         4         4       4            4           mayadata.io/data-plane=true   33m   name=openebs-ndm(existing),openebs-upgrade.dao.mayadata.io/component-group=ndm,openebs-upgrade.dao.mayadata.io/component-name=openebs-ndm,openebs-upgrade.dao.mayadata.io/component-subgroup=daemon,openebs-upgrade.dao.mayadata.io/managed=true,openebs.io/component-name=ndm(existing),openebs.io/version=1.9.0(existing)
```
```
NAME                   READY   UP-TO-DATE   AVAILABLE   AGE   LABELS
openebs-ndm-operator   1/1     1            1           44m   name=openebs-ndm-operator(existing),openebs-upgrade.dao.mayadata.io/component-group=ndm,openebs-upgrade.dao.mayadata.io/component-name=openebs-ndm-operator,openebs-upgrade.dao.mayadata.io/component-subgroup=operator,openebs-upgrade.dao.mayadata.io/managed=true,openebs.io/component-name=ndm-operator(existing),openebs.io/version=1.9.0(existing)
```
```
NAME                 DATA   AGE   LABELS
openebs-ndm-config   1      45m   openebs-upgrade.dao.mayadata.io/component-group=ndm,openebs-upgrade.dao.mayadata.io/component-name=openebs-ndm-config,openebs-upgrade.dao.mayadata.io/managed=true,openebs.io/component-name=ndm-config(existing)
```
For CSI related components
```
NAME                     DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE   LABELS
openebs-cstor-csi-node   3         3         3       3            3           <none>          37m   name=openebs-cstor-csi-node(existing),openebs-upgrade.dao.mayadata.io/component-group=cstor-csi,openebs-upgrade.dao.mayadata.io/component-name=openebs-cstor-csi-node,openebs-upgrade.dao.mayadata.io/managed=true,openebs.io/component-name=openebs-cstor-csi-node(existing),openebs.io/version=1.9.0(existing)
```
```
NAME                           READY   AGE   LABELS
openebs-cstor-csi-controller   1/1     39m   name=openebs-cstor-csi-controller(existing)
,openebs-upgrade.dao.mayadata.io/component-group=cstor-csi,openebs-upgrade.dao.mayadata.io/component-name=openebs-cstor-csi-controller,openebs-upgrade.dao.mayadata.io/managed=true,openebs.io/component-name=openebs-cstor-csi-controller(existing)
,openebs.io/version=1.9.0(existing)
```
For maya-apiserver
```
NAME             READY   UP-TO-DATE   AVAILABLE   AGE   LABELS
maya-apiserver   1/1     1            1           41m   name=maya-apiserver(existing),openebs-upgrade.dao.mayadata.io/component-group=maya-apiserver,openebs-upgrade.dao.mayadata.io/component-name=maya-apiserver,openebs-upgrade.dao.mayadata.io/managed=true,openebs.io/component-name=maya-apiserver(existing),openebs.io/version=1.9.0(existing)
```
```
NAME                     TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE   LABELS
maya-apiserver-service   ClusterIP   10.97.161.27   <none>        5656/TCP   41m   openebs-upgrade.dao.mayadata.io/component-group=maya-apiserver,openebs-upgrade.dao.mayadata.io/component-name=maya-apiserver-service,openebs-upgrade.dao.mayadata.io/managed=true,openebs.io/component-name=maya-apiserver-svc(existing)
```

For CSPC operator:
```
NAME            READY   UP-TO-DATE   AVAILABLE   AGE   LABELS
cspc-operator   1/1     1            1           43m   name=cspc-operator(existing),openebs-upgrade.dao.mayadata.io/component-group=cspc,openebs-upgrade.dao.mayadata.io/component-name=cspc-operator,openebs-upgrade.dao.mayadata.io/managed=true,openebs.io/component-name=cspc-operator(existing),openebs.io/version=1.9.0(existing)

```

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>