### PR TITLE
fix(install): update enterprise default docker registry

### DIFF
--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -56,7 +56,13 @@ func (p *Planner) setDefaultStoragePathIfNotSet() error {
 // or not, if not then it adds one.
 func (p *Planner) setDefaultImagePrefixIfNotSet() error {
 	if p.ObservedOpenEBS.Spec.ImagePrefix == "" {
-		p.ObservedOpenEBS.Spec.ImagePrefix = "quay.io/openebs/"
+		// Default docker registry for OpenEBS enterprise installation will
+		// be "mayadataio/" while for community edition will be "quay.io/openebs/".
+		if strings.HasSuffix(p.ObservedOpenEBS.Spec.Version, "ee") {
+			p.ObservedOpenEBS.Spec.ImagePrefix = "mayadataio/"
+		} else {
+			p.ObservedOpenEBS.Spec.ImagePrefix = "quay.io/openebs/"
+		}
 	} else if !strings.HasSuffix(p.ObservedOpenEBS.Spec.ImagePrefix, "/") {
 		p.ObservedOpenEBS.Spec.ImagePrefix = p.ObservedOpenEBS.Spec.ImagePrefix + "/"
 	}


### PR DESCRIPTION
This PR will enable `openebs-upgrade` to make use of **mayadataio/** as the default docker registry for OpenEBS enterprise docker images if none provided.

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>