### PR TITLE
enhance(install): add OpenEBS 1.10.0 install/upgrade support

### DIFF
--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -20,6 +20,9 @@ spec:
           - matchReferenceExpressions:
               - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
                 refKey: metadata.uid # match this ann value against watch UID
+          - matchReferenceExpressions:
+              - key: metadata.annotations.openebs-upgrade\.dao\.mayadata\.io/openebs-uid
+                refKey: metadata.uid # match this ann value against watch UID
     - apiVersion: apps/v1
       resource: deployments
       updateStrategy:
@@ -28,6 +31,9 @@ spec:
         selectorTerms:
           - matchReferenceExpressions:
               - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
+                refKey: metadata.uid # match this ann value against watch UID
+          - matchReferenceExpressions:
+              - key: metadata.annotations.openebs-upgrade\.dao\.mayadata\.io/openebs-uid
                 refKey: metadata.uid # match this ann value against watch UID
     - apiVersion: apps/v1
       resource: statefulsets
@@ -38,6 +44,9 @@ spec:
           - matchReferenceExpressions:
               - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
                 refKey: metadata.uid # match this ann value against watch UID
+          - matchReferenceExpressions:
+              - key: metadata.annotations.openebs-upgrade\.dao\.mayadata\.io/openebs-uid
+                refKey: metadata.uid # match this ann value against watch UID
     - apiVersion: v1
       resource: configmaps
       updateStrategy:
@@ -46,6 +55,9 @@ spec:
         selectorTerms:
           - matchReferenceExpressions:
               - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
+                refKey: metadata.uid # match this ann value against watch UID
+          - matchReferenceExpressions:
+              - key: metadata.annotations.openebs-upgrade\.dao\.mayadata\.io/openebs-uid
                 refKey: metadata.uid # match this ann value against watch UID
     - apiVersion: v1
       resource: services
@@ -56,30 +68,31 @@ spec:
           - matchReferenceExpressions:
               - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
                 refKey: metadata.uid # match this ann value against watch UID
+          - matchReferenceExpressions:
+              - key: metadata.annotations.openebs-upgrade\.dao\.mayadata\.io/openebs-uid
+                refKey: metadata.uid # match this ann value against watch UID
     - apiVersion: rbac.authorization.k8s.io/v1beta1
       resource: clusterrolebindings
       updateStrategy:
         method: InPlace
-      advancedSelector:
-        selectorTerms:
-          - matchExpressions:
-              - key: metadata.name
-                operator: In
-                values: ["openebs-maya-operator", "openebs-cstor-csi-snapshotter-binding", "openebs-cstor-csi-provisioner-binding",
-                         "openebs-cstor-csi-attacher-binding", "openebs-cstor-csi-cluster-registrar-binding",
-                         "openebs-cstor-csi-registrar-binding"]
+      nameSelector:
+        - openebs-maya-operator
+        - openebs-cstor-csi-snapshotter-binding
+        - openebs-cstor-csi-provisioner-binding
+        - openebs-cstor-csi-attacher-binding
+        - openebs-cstor-csi-cluster-registrar-binding
+        - openebs-cstor-csi-registrar-binding
     - apiVersion: rbac.authorization.k8s.io/v1beta1
       resource: clusterroles
       updateStrategy:
         method: InPlace
-      advancedSelector:
-        selectorTerms:
-          - matchExpressions:
-              - key: metadata.name
-                operator: In
-                values: ["openebs-maya-operator", "openebs-cstor-csi-snapshotter-role", "openebs-cstor-csi-provisioner-role",
-                         "openebs-cstor-csi-attacher-role", "openebs-cstor-csi-cluster-registrar-role",
-                         "openebs-cstor-csi-registrar-role"]
+      nameSelector:
+        - openebs-maya-operator
+        - openebs-cstor-csi-snapshotter-role
+        - openebs-cstor-csi-provisioner-role
+        - openebs-cstor-csi-attacher-role
+        - openebs-cstor-csi-cluster-registrar-role
+        - openebs-cstor-csi-registrar-role
     - apiVersion: v1
       resource: serviceaccounts
       updateStrategy:
@@ -89,29 +102,33 @@ spec:
           - matchReferenceExpressions:
               - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
                 refKey: metadata.uid # match this ann value against watch UID
+          - matchReferenceExpressions:
+              - key: metadata.annotations.openebs-upgrade\.dao\.mayadata\.io/openebs-uid
+                refKey: metadata.uid # match this ann value against watch UID
     - apiVersion: apiextensions.k8s.io/v1beta1
       resource: customresourcedefinitions
       updateStrategy:
         method: InPlace
-      advancedSelector:
-        selectorTerms:
-          - matchExpressions:
-              - key: metadata.name
-                operator: In
-                values: ["cstorpoolclusters.openebs.io", "csinodeinfos.csi.storage.k8s.io", "csivolumes.openebs.io",
-                         "volumesnapshotclasses.snapshot.storage.k8s.io", "volumesnapshotcontents.snapshot.storage.k8s.io",
-                         "volumesnapshots.snapshot.storage.k8s.io", "cstorpoolclusters.cstor.openebs.io",
-                         "cstorpoolinstances.cstor.openebs.io", "cstorvolumeattachments.cstor.openebs.io"]
+      nameSelector:
+        - cstorpoolclusters.openebs.io
+        - csinodeinfos.csi.storage.k8s.io
+        - csivolumes.openebs.io
+        - volumesnapshotclasses.snapshot.storage.k8s.io
+        - volumesnapshotcontents.snapshot.storage.k8s.io
+        - volumesnapshots.snapshot.storage.k8s.io
+        - cstorpoolclusters.cstor.openebs.io
+        - cstorpoolinstances.cstor.openebs.io
+        - cstorvolumeattachments.cstor.openebs.io
+        - cstorvolumes.cstor.openebs.io
+        - cstorvolumeconfigs.cstor.openebs.io
+        - cstorvolumepolicies.cstor.openebs.io
+        - cstorvolumereplicas.cstor.openebs.io
     - apiVersion: storage.k8s.io/v1beta1
       resource: csidrivers
       updateStrategy:
         method: InPlace
-      advancedSelector:
-        selectorTerms:
-          - matchExpressions:
-              - key: metadata.name
-                operator: In
-                values: ["cstor.csi.openebs.io"]
+      nameSelector:
+        - cstor.csi.openebs.io
   hooks:
     sync:
       inline:

--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -9,98 +9,109 @@ spec:
     apiVersion: dao.mayadata.io/v1alpha1
     resource: openebses
   attachments:
-  - apiVersion: dao.mayadata.io/v1alpha1
-    resource: openebses
-  - apiVersion: apps/v1
-    resource: daemonsets
-    updateStrategy:
-      method: InPlace
-    advancedSelector:
-      selectorTerms:
-      - matchReferenceExpressions:
-        - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
-          refKey: metadata.uid # match this ann value against watch UID
-  - apiVersion: apps/v1
-    resource: deployments
-    updateStrategy:
-      method: InPlace
-    advancedSelector:
-      selectorTerms:
-      - matchReferenceExpressions:
-        - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
-          refKey: metadata.uid # match this ann value against watch UID
-  - apiVersion: apps/v1
-    resource: statefulsets
-    updateStrategy:
-      method: InPlace
-    advancedSelector:
-      selectorTerms:
-      - matchReferenceExpressions:
-        - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
-          refKey: metadata.uid # match this ann value against watch UID
-  - apiVersion: v1
-    resource: configmaps
-    updateStrategy:
-      method: InPlace
-    advancedSelector:
-      selectorTerms:
-      - matchReferenceExpressions:
-        - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
-          refKey: metadata.uid # match this ann value against watch UID
-  - apiVersion: v1
-    resource: services
-    updateStrategy:
-      method: InPlace
-    advancedSelector:
-      selectorTerms:
-      - matchReferenceExpressions:
-        - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
-          refKey: metadata.uid # match this ann value against watch UID
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
-    resource: clusterrolebindings
-    updateStrategy:
-      method: InPlace
-    advancedSelector:
-      selectorTerms:
-      - matchExpressions:
-        - key: metadata.name
-          operator: In
-          values: ["openebs-maya-operator", "openebs-cstor-csi-snapshotter-binding", "openebs-cstor-csi-provisioner-binding",
-                   "openebs-cstor-csi-attacher-binding", "openebs-cstor-csi-cluster-registrar-binding",
-                   "openebs-cstor-csi-registrar-binding"]
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
-    resource: clusterroles
-    updateStrategy:
-      method: InPlace
-    advancedSelector:
-      selectorTerms:
-      - matchExpressions:
-        - key: metadata.name
-          operator: In
-          values: ["openebs-maya-operator", "openebs-cstor-csi-snapshotter-role", "openebs-cstor-csi-provisioner-role",
-                   "openebs-cstor-csi-attacher-role", "openebs-cstor-csi-cluster-registrar-role",
-                   "openebs-cstor-csi-registrar-role"]
-  - apiVersion: v1
-    resource: serviceaccounts
-    updateStrategy:
-      method: InPlace
-    advancedSelector:
-      selectorTerms:
-      - matchReferenceExpressions:
-        - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
-          refKey: metadata.uid # match this ann value against watch UID
-  - apiVersion: apiextensions.k8s.io/v1beta1
-    resource: customresourcedefinitions
-    updateStrategy:
-      method: InPlace
-    advancedSelector:
-      selectorTerms:
-      - matchExpressions:
-        - key: metadata.name
-          operator: In
-          values: ["cstorpoolclusters.openebs.io", "csinodeinfos.csi.storage.k8s.io", "csivolumes.openebs.io",
-                    "volumesnapshotclasses.snapshot.storage.k8s.io", "volumesnapshotcontents.snapshot.storage.k8s.io",
-                    "volumesnapshots.snapshot.storage.k8s.io"]
+    - apiVersion: dao.mayadata.io/v1alpha1
+      resource: openebses
+    - apiVersion: apps/v1
+      resource: daemonsets
+      updateStrategy:
+        method: InPlace
+      advancedSelector:
+        selectorTerms:
+          - matchReferenceExpressions:
+              - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
+                refKey: metadata.uid # match this ann value against watch UID
+    - apiVersion: apps/v1
+      resource: deployments
+      updateStrategy:
+        method: InPlace
+      advancedSelector:
+        selectorTerms:
+          - matchReferenceExpressions:
+              - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
+                refKey: metadata.uid # match this ann value against watch UID
+    - apiVersion: apps/v1
+      resource: statefulsets
+      updateStrategy:
+        method: InPlace
+      advancedSelector:
+        selectorTerms:
+          - matchReferenceExpressions:
+              - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
+                refKey: metadata.uid # match this ann value against watch UID
+    - apiVersion: v1
+      resource: configmaps
+      updateStrategy:
+        method: InPlace
+      advancedSelector:
+        selectorTerms:
+          - matchReferenceExpressions:
+              - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
+                refKey: metadata.uid # match this ann value against watch UID
+    - apiVersion: v1
+      resource: services
+      updateStrategy:
+        method: InPlace
+      advancedSelector:
+        selectorTerms:
+          - matchReferenceExpressions:
+              - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
+                refKey: metadata.uid # match this ann value against watch UID
+    - apiVersion: rbac.authorization.k8s.io/v1beta1
+      resource: clusterrolebindings
+      updateStrategy:
+        method: InPlace
+      advancedSelector:
+        selectorTerms:
+          - matchExpressions:
+              - key: metadata.name
+                operator: In
+                values: ["openebs-maya-operator", "openebs-cstor-csi-snapshotter-binding", "openebs-cstor-csi-provisioner-binding",
+                         "openebs-cstor-csi-attacher-binding", "openebs-cstor-csi-cluster-registrar-binding",
+                         "openebs-cstor-csi-registrar-binding"]
+    - apiVersion: rbac.authorization.k8s.io/v1beta1
+      resource: clusterroles
+      updateStrategy:
+        method: InPlace
+      advancedSelector:
+        selectorTerms:
+          - matchExpressions:
+              - key: metadata.name
+                operator: In
+                values: ["openebs-maya-operator", "openebs-cstor-csi-snapshotter-role", "openebs-cstor-csi-provisioner-role",
+                         "openebs-cstor-csi-attacher-role", "openebs-cstor-csi-cluster-registrar-role",
+                         "openebs-cstor-csi-registrar-role"]
+    - apiVersion: v1
+      resource: serviceaccounts
+      updateStrategy:
+        method: InPlace
+      advancedSelector:
+        selectorTerms:
+          - matchReferenceExpressions:
+              - key: metadata.annotations.dao\.mayadata\.io/openebs-uid
+                refKey: metadata.uid # match this ann value against watch UID
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      resource: customresourcedefinitions
+      updateStrategy:
+        method: InPlace
+      advancedSelector:
+        selectorTerms:
+          - matchExpressions:
+              - key: metadata.name
+                operator: In
+                values: ["cstorpoolclusters.openebs.io", "csinodeinfos.csi.storage.k8s.io", "csivolumes.openebs.io",
+                         "volumesnapshotclasses.snapshot.storage.k8s.io", "volumesnapshotcontents.snapshot.storage.k8s.io",
+                         "volumesnapshots.snapshot.storage.k8s.io", "cstorpoolclusters.cstor.openebs.io",
+                         "cstorpoolinstances.cstor.openebs.io", "cstorvolumeattachments.cstor.openebs.io"]
+    - apiVersion: storage.k8s.io/v1beta1
+      resource: csidrivers
+      updateStrategy:
+        method: InPlace
+      advancedSelector:
+        selectorTerms:
+          - matchExpressions:
+              - key: metadata.name
+                operator: In
+                values: ["cstor.csi.openebs.io"]
   hooks:
     sync:
       inline:

--- a/controller/openebs/apiserver.go
+++ b/controller/openebs/apiserver.go
@@ -60,6 +60,21 @@ func (p *Planner) updateMayaAPIServer(deploy *unstructured.Unstructured) error {
 		} else if envName == "OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG" {
 			err = unstructured.SetNestedField(env.Object, strconv.FormatBool(
 				*p.ObservedOpenEBS.Spec.CreateDefaultStorageConfig), "spec", "value")
+		} else if envName == "OPENEBS_IO_BASE_DIR" {
+			err = unstructured.SetNestedField(env.Object,
+				p.ObservedOpenEBS.Spec.DefaultStoragePath, "spec", "value")
+		} else if envName == "OPENEBS_IO_CSTOR_TARGET_DIR" {
+			err = unstructured.SetNestedField(env.Object,
+				p.ObservedOpenEBS.Spec.DefaultStoragePath+"/sparse", "spec", "value")
+		} else if envName == "OPENEBS_IO_CSTOR_POOL_SPARSE_DIR" {
+			err = unstructured.SetNestedField(env.Object,
+				p.ObservedOpenEBS.Spec.DefaultStoragePath+"/sparse", "spec", "value")
+		} else if envName == "OPENEBS_IO_JIVA_POOL_DIR" {
+			err = unstructured.SetNestedField(env.Object,
+				p.ObservedOpenEBS.Spec.DefaultStoragePath, "spec", "value")
+		} else if envName == "OPENEBS_IO_LOCALPV_HOSTPATH_DIR" {
+			err = unstructured.SetNestedField(env.Object,
+				p.ObservedOpenEBS.Spec.DefaultStoragePath+"/local", "spec", "value")
 		} else if envName == "OPENEBS_IO_JIVA_CONTROLLER_IMAGE" {
 			err = unstructured.SetNestedField(env.Object,
 				p.ObservedOpenEBS.Spec.JivaConfig.Image, "spec", "value")

--- a/controller/openebs/crd.go
+++ b/controller/openebs/crd.go
@@ -22,8 +22,12 @@ import (
 func (p *Planner) getDesiredCustomResourceDefinition(crd *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	var err error
 	switch crd.GetName() {
-	case types.CSPCCRDNameKey:
-		err = p.updateCSPCCRD(crd)
+	case types.CSPCCRDV1alpha1NameKey:
+		err = p.updateCSPCCRDV1alpha1(crd)
+	case types.CSPCCRDV1NameKey:
+		err = p.updateCSPCCRDV1(crd)
+	case types.CSPICRDV1NameKey:
+		err = p.updateCSPICRDV1(crd)
 	case types.CSINodeInfoCRDNameKey:
 		err = p.updateCSINodeInfoCRD(crd)
 	case types.CSIVolumeCRDNameKey:
@@ -34,6 +38,16 @@ func (p *Planner) getDesiredCustomResourceDefinition(crd *unstructured.Unstructu
 		err = p.updateVolumeSnapshotClassCRD(crd)
 	case types.VolumeSnapshotContentCRDNameKey:
 		err = p.updateVolumeSnapshotContentCRD(crd)
+	case types.CStorVolumeAttachmentsCRDNameKey:
+		err = p.updateCStorVolumeAttachmentsCRD(crd)
+	case types.CStorVolumesCRDV1NameKey:
+		err = p.updateCStorVolumesCRDV1(crd)
+	case types.CStorVolumeConfigsCRDV1NameKey:
+		err = p.updateCStorVolumeConfigsCRDV1(crd)
+	case types.CStorVolumeReplicasCRDV1NameKey:
+		err = p.updateCStorVolumeReplicasCRDV1(crd)
+	case types.CStorVolumePoliciesCRDV1NameKey:
+		err = p.updateCStorVolumePoliciesCRDV1(crd)
 	}
 	if err != nil {
 		return crd, err
@@ -139,8 +153,25 @@ func (p *Planner) updateVolumeSnapshotContentCRD(crd *unstructured.Unstructured)
 	return nil
 }
 
-// updateCSPCCRD updates the CSPC CRD manifest as per the reconcile.ObservedOpenEBS values.
-func (p *Planner) updateCSPCCRD(crd *unstructured.Unstructured) error {
+// updateCStorVolumeAttachmentsCRD updates the CStor volume attachments CRD manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateCStorVolumeAttachmentsCRD(crd *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := crd.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for CStor volume attachments CRD
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: cstorvolumeattachments.cstor.openebs.io
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CStorVolumeAttachmentsCRDNameKey
+	// set the desired labels
+	crd.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateCSPCCRDV1 updates the CSPC V1 CRD manifest as per the reconcile.ObservedOpenEBS values.
+func (p *Planner) updateCSPCCRDV1(crd *unstructured.Unstructured) error {
 	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
 	desiredLabels := crd.GetLabels()
 	if desiredLabels == nil {
@@ -151,7 +182,113 @@ func (p *Planner) updateCSPCCRD(crd *unstructured.Unstructured) error {
 	// 2. openebs-upgrade.dao.mayadata.io/component-name: cstorpoolclusters.cstor.openebs.io
 	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
 		types.CSPCComponentGroupLabelValue
-	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CSPCCRDNameKey
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CSPCCRDV1NameKey
+	// set the desired labels
+	crd.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateCSPCCRDV1alpha1 updates the CSPC V1alpha1 CRD manifest as per the reconcile.ObservedOpenEBS values.
+func (p *Planner) updateCSPCCRDV1alpha1(crd *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := crd.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for CSPC CRD
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: cspc
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: cstorpoolclusters.openebs.io
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.CSPCComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CSPCCRDV1alpha1NameKey
+	// set the desired labels
+	crd.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateCSPICRDV1 updates the CSPI V1 CRD manifest as per the reconcile.ObservedOpenEBS values.
+func (p *Planner) updateCSPICRDV1(crd *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := crd.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for CSPI CRD
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: cspi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: cstorpoolinstances.cstor.openebs.io
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.CSPIComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CSPICRDV1NameKey
+	// set the desired labels
+	crd.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateCStorVolumesCRDV1 updates the CStor volumes CRD(V1) manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateCStorVolumesCRDV1(crd *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := crd.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for CStor volumes CRD
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: cstorvolumes.cstor.openebs.io
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CStorVolumesCRDV1NameKey
+	// set the desired labels
+	crd.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateCStorVolumeConfigsCRDV1 updates the CStor volume configs CRD(V1) manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateCStorVolumeConfigsCRDV1(crd *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := crd.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for CStor volume configs CRD
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: cstorvolumeconfigs.cstor.openebs.io
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CStorVolumeConfigsCRDV1NameKey
+	// set the desired labels
+	crd.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateCStorVolumePoliciesCRDV1 updates the CStor volume policies CRD(V1) manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateCStorVolumePoliciesCRDV1(crd *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := crd.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for CStor volume policies CRD
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: cstorvolumepolicies.cstor.openebs.io
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CStorVolumePoliciesCRDV1NameKey
+	// set the desired labels
+	crd.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateCStorVolumeReplicasCRDV1 updates the CStor volume replicas CRD(V1) manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateCStorVolumeReplicasCRDV1(crd *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := crd.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for CStor volume replicas CRD
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: cstorvolumereplicas.cstor.openebs.io
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CStorVolumeReplicasCRDV1NameKey
 	// set the desired labels
 	crd.SetLabels(desiredLabels)
 

--- a/controller/openebs/jiva.go
+++ b/controller/openebs/jiva.go
@@ -20,7 +20,30 @@ import (
 const (
 	// DefaultJivaReplicaCount is the default value of jiva replicas
 	DefaultJivaReplicaCount int32 = 3
+	// JivaVersion162 is the supported image tag for Jiva components
+	// for OpenEBS version 1.6.0.
+	JivaVersion162 string = "1.6.2"
+	// JivaVersion171 is the supported image tag for Jiva components
+	// for OpenEBS version 1.7.0.
+	JivaVersion171 string = "1.7.1"
 )
+
+// supportedJivaVersionForOpenEBSVersion stores the mapping for
+// Jiva to OpenEBS version i.e., a Jiva version for each of the
+// supported OpenEBS versions.
+// Note: This will be referred to form the container images in
+// order to install/update jiva controller/replica components for a
+// particular OpenEBS version.
+//
+// NOTE: There will be an entry for only those OpenEBS versions and the
+// supported Jiva versions where the image tag for Jiva images are different
+// from the OpenEBS version such as in case of OpenEBS version 1.6.0, the jiva
+// controller/replica image that should be used is 1.6.2 instead of 1.6.0 since
+// 1.6.2 have some critical fixes which 1.6.0 doesn't have.
+var supportedJivaVersionForOpenEBSVersion = map[string]string{
+	types.OpenEBSVersion160: JivaVersion162,
+	types.OpenEBSVersion170: JivaVersion171,
+}
 
 // Set the default values for JIVA.
 func (p *Planner) setJIVADefaultsIfNotSet() error {
@@ -30,7 +53,11 @@ func (p *Planner) setJIVADefaultsIfNotSet() error {
 	// form the jiva image being used by jiva-controller and
 	// replica.
 	if p.ObservedOpenEBS.Spec.JivaConfig.ImageTag == "" {
-		p.ObservedOpenEBS.Spec.JivaConfig.ImageTag = p.ObservedOpenEBS.Spec.Version
+		if jivaVersion, exist := supportedJivaVersionForOpenEBSVersion[p.ObservedOpenEBS.Spec.Version]; exist {
+			p.ObservedOpenEBS.Spec.JivaConfig.ImageTag = jivaVersion
+		} else {
+			p.ObservedOpenEBS.Spec.JivaConfig.ImageTag = p.ObservedOpenEBS.Spec.Version
+		}
 	}
 	p.ObservedOpenEBS.Spec.JivaConfig.Image = p.ObservedOpenEBS.Spec.ImagePrefix +
 		"jiva:" + p.ObservedOpenEBS.Spec.JivaConfig.ImageTag

--- a/controller/openebs/ndm.go
+++ b/controller/openebs/ndm.go
@@ -36,6 +36,7 @@ var supportedNDMVersionForOpenEBSVersion = map[string]string{
 	types.OpenEBSVersion180:   types.NDMVersion048,
 	types.OpenEBSVersion190:   types.NDMVersion049,
 	types.OpenEBSVersion190EE: types.NDMVersion049EE,
+	types.OpenEBSVersion1100:  types.NDMVersion050,
 }
 
 // add/update NDM defaults if not already provided
@@ -367,6 +368,12 @@ func (p *Planner) updateNDM(daemonset *unstructured.Unstructured) error {
 			if err != nil {
 				return err
 			}
+		} else if volumeName == "basepath" {
+			err = unstructured.SetNestedField(obj.Object,
+				p.ObservedOpenEBS.Spec.DefaultStoragePath+"/ndm", "spec", "hostPath", "path")
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	}
@@ -417,6 +424,12 @@ func (p *Planner) updateNDM(daemonset *unstructured.Unstructured) error {
 		if vmName == "sparsepath" {
 			err = unstructured.SetNestedField(vm.Object,
 				p.ObservedOpenEBS.Spec.NDMDaemon.Sparse.Path, "spec", "mountPath")
+			if err != nil {
+				return err
+			}
+		} else if vmName == "basepath" {
+			err = unstructured.SetNestedField(vm.Object,
+				p.ObservedOpenEBS.Spec.DefaultStoragePath+"/ndm", "spec", "mountPath")
 			if err != nil {
 				return err
 			}

--- a/deploy/example.yaml
+++ b/deploy/example.yaml
@@ -1,4 +1,3 @@
-
 # This configuration is for OpenEBS Installation, ControlPlaneUpgrade
 # and unInstallation.
 apiVersion: dao.mayadata.io/v1alpha1
@@ -325,6 +324,10 @@ spec:
       # example image for volumeManager -> "quay.io/openebs/cstor-volume-manager:1.9.0"
       # this field should only contain the image tag, for example, 1.9.0
       imageTag:
+    admissionServer:
+      # example image for volumeManager -> "quay.io/openebs/cstor-webhook-amd64:1.10.0"
+      # this field should only contain the image tag, for example, 1.10.0
+      imageTag:
     cspcOperator:
       enabled:
       # example image for cspc-operator -> "quay.io/openebs/cspc-operator:1.9.0"
@@ -397,6 +400,6 @@ spec:
   options:
 
 status:
-    # Online and Error could be some of the phases
-    phase:
-    reason:
+  # Online and Error could be some of the phases
+  phase:
+  reason:

--- a/templates/openebs-operator-1.10.0.yaml
+++ b/templates/openebs-operator-1.10.0.yaml
@@ -11,62 +11,47 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-maya-operator
 rules:
-- apiGroups: ["*"]
-  resources: ["nodes", "nodes/proxy"]
-  verbs: ["*"]
-- apiGroups: ["*"]
-  resources: ["namespaces", "services", "pods", "pods/exec", "deployments", "deployments/finalizers", "replicationcontrollers", "replicasets", "events", "endpoints", "configmaps", "secrets", "jobs", "cronjobs"]
-  verbs: ["*"]
-- apiGroups: ["*"]
-  resources: ["statefulsets", "daemonsets"]
-  verbs: ["*"]
-- apiGroups: ["*"]
-  resources: ["resourcequotas", "limitranges"]
-  verbs: ["list", "watch"]
-- apiGroups: ["*"]
-  resources: ["ingresses", "horizontalpodautoscalers", "verticalpodautoscalers", "certificatesigningrequests"]
-  verbs: ["list", "watch"]
-- apiGroups: ["*"]
-  resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]
-  verbs: ["*"]
-- apiGroups: ["volumesnapshot.external-storage.k8s.io"]
-  resources: ["volumesnapshots", "volumesnapshotdatas"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: [ "get", "list", "create", "update", "delete", "patch"]
-- apiGroups: ["*"]
-  resources: [ "disks", "blockdevices", "blockdeviceclaims"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "cstorpoolclusters", "storagepoolclaims", "storagepoolclaims/finalizers", "cstorpoolclusters/finalizers", "storagepools"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "castemplates", "runtasks"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "cstorpools", "cstorpools/finalizers", "cstorvolumereplicas", "cstorvolumes", "cstorvolumeclaims", "cstorvolumepolicies"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "cstorpoolinstances", "cstorpoolinstances/finalizers"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "cstorbackups", "cstorrestores", "cstorcompletedbackups"]
-  verbs: ["*" ]
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
-  verbs: ["get", "create", "list", "delete", "update", "patch"]
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]
-- apiGroups: ["*"]
-  resources: ["upgradetasks"]
-  verbs: ["*"]
-- apiGroups: ["*"]
-  resources: ["poddisruptionbudgets"]
-  verbs: ["get", "list", "create", "delete", "watch"]
+  - apiGroups: ["*"]
+    resources: ["nodes", "nodes/proxy"]
+    verbs: ["*"]
+  - apiGroups: ["*"]
+    resources: ["namespaces", "services", "pods", "pods/exec", "deployments", "deployments/finalizers", "replicationcontrollers", "replicasets", "events", "endpoints", "configmaps", "secrets", "jobs", "cronjobs"]
+    verbs: ["*"]
+  - apiGroups: ["*"]
+    resources: ["statefulsets", "daemonsets"]
+    verbs: ["*"]
+  - apiGroups: ["*"]
+    resources: ["resourcequotas", "limitranges"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["*"]
+    resources: ["ingresses", "horizontalpodautoscalers", "verticalpodautoscalers", "certificatesigningrequests"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["*"]
+    resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]
+    verbs: ["*"]
+  - apiGroups: ["volumesnapshot.external-storage.k8s.io"]
+    resources: ["volumesnapshots", "volumesnapshotdatas"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: [ "get", "list", "create", "update", "delete", "patch"]
+  - apiGroups: ["openebs.io"]
+    resources: [ "*"]
+    verbs: ["*" ]
+  - apiGroups: ["cstor.openebs.io"]
+    resources: [ "*"]
+    verbs: ["*" ]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    verbs: ["get", "create", "list", "delete", "update", "patch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+  - apiGroups: ["*"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "create", "delete", "watch"]
 ---
 # Bind the Service Account with the Role Privileges.
 # TODO: Check if default account also needs to be there
@@ -75,9 +60,9 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-maya-operator
 subjects:
-- kind: ServiceAccount
-  name: openebs-maya-operator
-  namespace: openebs
+  - kind: ServiceAccount
+    name: openebs-maya-operator
+    namespace: openebs
 roleRef:
   kind: ClusterRole
   name: openebs-maya-operator
@@ -91,7 +76,7 @@ metadata:
   labels:
     name: maya-apiserver
     openebs.io/component-name: maya-apiserver
-    openebs.io/version: 1.9.0
+    openebs.io/version: 1.10.0
 spec:
   selector:
     matchLabels:
@@ -106,80 +91,136 @@ spec:
       labels:
         name: maya-apiserver
         openebs.io/component-name: maya-apiserver
-        openebs.io/version: 1.9.0
+        openebs.io/version: 1.10.0
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
-      - name: maya-apiserver
-        imagePullPolicy: IfNotPresent
-        image: quay.io/openebs/m-apiserver:1.9.0
-        ports:
-        - containerPort: 5656
-        env:
-        - name: OPENEBS_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: OPENEBS_SERVICE_ACCOUNT
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.serviceAccountName
-        - name: OPENEBS_MAYA_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
-          value: "true"
-        - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
-          value: "false"
-        - name: OPENEBS_IO_BASE_DIR
-          value: "/var/openebs"
-        - name: OPENEBS_IO_CSTOR_TARGET_DIR
-          value: "/var/openebs/sparse"
-        - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
-          value: "/var/openebs/sparse"
-        - name: OPENEBS_IO_JIVA_POOL_DIR
-          value: "/var/openebs"
-        - name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
-          value: "/var/openebs/local"
-        - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "quay.io/openebs/jiva:1.9.0"
-        - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "quay.io/openebs/jiva:1.9.0"
-        - name: OPENEBS_IO_JIVA_REPLICA_COUNT
-          value: "3"
-        - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
-          value: "quay.io/openebs/cstor-istgt:1.9.0"
-        - name: OPENEBS_IO_CSTOR_POOL_IMAGE
-          value: "quay.io/openebs/cstor-pool:1.9.0"
-        - name: OPENEBS_IO_CSTOR_POOL_MGMT_IMAGE
-          value: "quay.io/openebs/cstor-pool-mgmt:1.9.0"
-        - name: OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
-          value: "quay.io/openebs/cstor-volume-mgmt:1.9.0"
-        - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "quay.io/openebs/m-exporter:1.9.0"
-        - name: OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
-          value: "quay.io/openebs/m-exporter:1.9.0"
-        - name: OPENEBS_IO_HELPER_IMAGE
-          value: "quay.io/openebs/linux-utils:1.9.0"
-        - name: OPENEBS_IO_ENABLE_ANALYTICS
-          value: "true"
-        - name: OPENEBS_IO_INSTALLER_TYPE
-          value: "openebs-operator"
-        livenessProbe:
-          exec:
-            command:
-            - /usr/local/bin/mayactl
-            - version
-          initialDelaySeconds: 30
-          periodSeconds: 60
-        readinessProbe:
-          exec:
-            command:
-            - /usr/local/bin/mayactl
-            - version
-          initialDelaySeconds: 30
-          periodSeconds: 60
+        - name: maya-apiserver
+          imagePullPolicy: IfNotPresent
+          image: quay.io/openebs/m-apiserver:1.10.0
+          ports:
+            - containerPort: 5656
+          env:
+            # OPENEBS_IO_KUBE_CONFIG enables maya api service to connect to K8s
+            # based on this config. This is ignored if empty.
+            # This is supported for maya api server version 0.5.2 onwards
+            #- name: OPENEBS_IO_KUBE_CONFIG
+            #  value: "/home/ubuntu/.kube/config"
+            # OPENEBS_IO_K8S_MASTER enables maya api service to connect to K8s
+            # based on this address. This is ignored if empty.
+            # This is supported for maya api server version 0.5.2 onwards
+            #- name: OPENEBS_IO_K8S_MASTER
+            #  value: "http://172.28.128.3:8080"
+            # OPENEBS_NAMESPACE provides the namespace of this deployment as an
+            # environment variable
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # OPENEBS_SERVICE_ACCOUNT provides the service account of this pod as
+            # environment variable
+            - name: OPENEBS_SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            # OPENEBS_MAYA_POD_NAME provides the name of this pod as
+            # environment variable
+            - name: OPENEBS_MAYA_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # If OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG is false then OpenEBS default
+            # storageclass and storagepool will not be created.
+            - name: OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+              value: "true"
+            # OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL decides whether default cstor sparse pool should be
+            # configured as a part of openebs installation.
+            # If "true" a default cstor sparse pool will be configured, if "false" it will not be configured.
+            # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+            # is set to true
+            - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
+              value: "false"
+            # OPENEBS_IO_INSTALL_CRD environment variable is used to enable/disable CRD installation
+            # from Maya API server. By default the CRDs will be installed
+            # - name: OPENEBS_IO_INSTALL_CRD
+            #   value: "true"
+            # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+            # Where OpenEBS can store required files. Default base path will be /var/openebs
+            - name: OPENEBS_IO_BASE_DIR
+              value: "/var/openebs"
+            # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
+            # to be used for saving the shared content between the side cars
+            # of cstor volume pod.
+            # The default path used is /var/openebs/sparse
+            - name: OPENEBS_IO_CSTOR_TARGET_DIR
+              value: "/var/openebs/sparse"
+            # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath
+            # to be used for saving the shared content between the side cars
+            # of cstor pool pod. This ENV is also used to indicate the location
+            # of the sparse devices.
+            # The default path used is /var/openebs/sparse
+            - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+              value: "/var/openebs/sparse"
+            # OPENEBS_IO_JIVA_POOL_DIR can be used to specify the hostpath
+            # to be used for default Jiva StoragePool loaded by OpenEBS
+            # The default path used is /var/openebs
+            # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+            # is set to true
+            - name: OPENEBS_IO_JIVA_POOL_DIR
+              value: "/var/openebs"
+            # OPENEBS_IO_LOCALPV_HOSTPATH_DIR can be used to specify the hostpath
+            # to be used for default openebs-hostpath storageclass loaded by OpenEBS
+            # The default path used is /var/openebs/local
+            # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+            # is set to true
+            - name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
+              value: "/var/openebs/local"
+            - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
+              value: "quay.io/openebs/jiva:1.10.0"
+            - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
+              value: "quay.io/openebs/jiva:1.10.0"
+            - name: OPENEBS_IO_JIVA_REPLICA_COUNT
+              value: "3"
+            - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
+              value: "quay.io/openebs/cstor-istgt:1.10.0"
+            - name: OPENEBS_IO_CSTOR_POOL_IMAGE
+              value: "quay.io/openebs/cstor-pool:1.10.0"
+            - name: OPENEBS_IO_CSTOR_POOL_MGMT_IMAGE
+              value: "quay.io/openebs/cstor-pool-mgmt:1.10.0"
+            - name: OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
+              value: "quay.io/openebs/cstor-volume-mgmt:1.10.0"
+            - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
+              value: "quay.io/openebs/m-exporter:1.10.0"
+            - name: OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
+              value: "quay.io/openebs/m-exporter:1.10.0"
+            - name: OPENEBS_IO_HELPER_IMAGE
+              value: "quay.io/openebs/linux-utils:1.10.0"
+            # OPENEBS_IO_ENABLE_ANALYTICS if set to true sends anonymous usage
+            # events to Google Analytics
+            - name: OPENEBS_IO_ENABLE_ANALYTICS
+              value: "true"
+            - name: OPENEBS_IO_INSTALLER_TYPE
+              value: "openebs-operator"
+          # OPENEBS_IO_ANALYTICS_PING_INTERVAL can be used to specify the duration (in hours)
+          # for periodic ping events sent to Google Analytics.
+          # Default is 24h.
+          # Minimum is 1h. You can convert this to weekly by setting 168h
+          #- name: OPENEBS_IO_ANALYTICS_PING_INTERVAL
+          #  value: "24h"
+          livenessProbe:
+            exec:
+              command:
+                - /usr/local/bin/mayactl
+                - version
+            initialDelaySeconds: 30
+            periodSeconds: 60
+          readinessProbe:
+            exec:
+              command:
+                - /usr/local/bin/mayactl
+                - version
+            initialDelaySeconds: 30
+            periodSeconds: 60
 ---
 apiVersion: v1
 kind: Service
@@ -190,10 +231,10 @@ metadata:
     openebs.io/component-name: maya-apiserver-svc
 spec:
   ports:
-  - name: api
-    port: 5656
-    protocol: TCP
-    targetPort: 5656
+    - name: api
+      port: 5656
+      protocol: TCP
+      targetPort: 5656
   selector:
     name: maya-apiserver
   sessionAffinity: None
@@ -206,7 +247,7 @@ metadata:
   labels:
     name: openebs-provisioner
     openebs.io/component-name: openebs-provisioner
-    openebs.io/version: 1.9.0
+    openebs.io/version: 1.10.0
 spec:
   selector:
     matchLabels:
@@ -221,30 +262,52 @@ spec:
       labels:
         name: openebs-provisioner
         openebs.io/component-name: openebs-provisioner
-        openebs.io/version: 1.9.0
+        openebs.io/version: 1.10.0
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
-      - name: openebs-provisioner
-        imagePullPolicy: IfNotPresent
-        image: quay.io/openebs/openebs-k8s-provisioner:1.9.0
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: OPENEBS_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test `pgrep -c "^openebs-provisi.*"` = 1
-          initialDelaySeconds: 30
-          periodSeconds: 60
+        - name: openebs-provisioner
+          imagePullPolicy: IfNotPresent
+          image: quay.io/openebs/openebs-k8s-provisioner:1.10.0
+          env:
+            # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
+            # based on this address. This is ignored if empty.
+            # This is supported for openebs provisioner version 0.5.2 onwards
+            #- name: OPENEBS_IO_K8S_MASTER
+            #  value: "http://10.128.0.12:8080"
+            # OPENEBS_IO_KUBE_CONFIG enables openebs provisioner to connect to K8s
+            # based on this config. This is ignored if empty.
+            # This is supported for openebs provisioner version 0.5.2 onwards
+            #- name: OPENEBS_IO_KUBE_CONFIG
+            #  value: "/home/ubuntu/.kube/config"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # OPENEBS_MAYA_SERVICE_NAME provides the maya-apiserver K8s service name,
+            # that provisioner should forward the volume create/delete requests.
+            # If not present, "maya-apiserver-service" will be used for lookup.
+            # This is supported for openebs provisioner version 0.5.3-RC1 onwards
+            #- name: OPENEBS_MAYA_SERVICE_NAME
+            #  value: "maya-apiserver-apiservice"
+            # Process name used for matching is limited to the 15 characters
+            # present in the pgrep output.
+            # So fullname can't be used here with pgrep (>15 chars).A regular expression
+            # that matches the entire command name has to specified.
+            # Anchor `^` : matches any string that starts with `openebs-provis`
+            # `.*`: matches any string that has `openebs-provis` followed by zero or more char
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - test `pgrep -c "^openebs-provisi.*"` = 1
+            initialDelaySeconds: 30
+            periodSeconds: 60
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -254,7 +317,7 @@ metadata:
   labels:
     name: openebs-snapshot-operator
     openebs.io/component-name: openebs-snapshot-operator
-    openebs.io/version: 1.9.0
+    openebs.io/version: 1.10.0
 spec:
   selector:
     matchLabels:
@@ -268,40 +331,64 @@ spec:
       labels:
         name: openebs-snapshot-operator
         openebs.io/component-name: openebs-snapshot-operator
-        openebs.io/version: 1.9.0
+        openebs.io/version: 1.10.0
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: snapshot-controller
-          image: quay.io/openebs/snapshot-controller:1.9.0
+          image: quay.io/openebs/snapshot-controller:1.10.0
           imagePullPolicy: IfNotPresent
           env:
-          - name: OPENEBS_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          # Process name used for matching is limited to the 15 characters
+          # present in the pgrep output.
+          # So fullname can't be used here with pgrep (>15 chars).A regular expression
+          # that matches the entire command name has to specified.
+          # Anchor `^` : matches any string that starts with `snapshot-contro`
+          # `.*`: matches any string that has `snapshot-contro` followed by zero or more char
           livenessProbe:
             exec:
               command:
-              - sh
-              - -c
-              - test `pgrep -c "^snapshot-contro.*"` = 1
+                - sh
+                - -c
+                - test `pgrep -c "^snapshot-contro.*"` = 1
             initialDelaySeconds: 30
             periodSeconds: 60
+        # OPENEBS_MAYA_SERVICE_NAME provides the maya-apiserver K8s service name,
+        # that snapshot controller should forward the snapshot create/delete requests.
+        # If not present, "maya-apiserver-service" will be used for lookup.
+        # This is supported for openebs provisioner version 0.5.3-RC1 onwards
+        #- name: OPENEBS_MAYA_SERVICE_NAME
+        #  value: "maya-apiserver-apiservice"
         - name: snapshot-provisioner
-          image: quay.io/openebs/snapshot-provisioner:1.9.0
+          image: quay.io/openebs/snapshot-provisioner:1.10.0
           imagePullPolicy: IfNotPresent
           env:
-          - name: OPENEBS_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          # OPENEBS_MAYA_SERVICE_NAME provides the maya-apiserver K8s service name,
+          # that snapshot provisioner  should forward the clone create/delete requests.
+          # If not present, "maya-apiserver-service" will be used for lookup.
+          # This is supported for openebs provisioner version 0.5.3-RC1 onwards
+          #- name: OPENEBS_MAYA_SERVICE_NAME
+          #  value: "maya-apiserver-apiservice"
+          # Process name used for matching is limited to the 15 characters
+          # present in the pgrep output.
+          # So fullname can't be used here with pgrep (>15 chars).A regular expression
+          # that matches the entire command name has to specified.
+          # Anchor `^` : matches any string that starts with `snapshot-provis`
+          # `.*`: matches any string that has `snapshot-provis` followed by zero or more char
           livenessProbe:
             exec:
               command:
-              - sh
-              - -c
-              - test `pgrep -c "^snapshot-provis.*"` = 1
+                - sh
+                - -c
+                - test `pgrep -c "^snapshot-provis.*"` = 1
             initialDelaySeconds: 30
             periodSeconds: 60
 ---
@@ -315,6 +402,9 @@ metadata:
   labels:
     openebs.io/component-name: ndm-config
 data:
+  # udev-probe is default or primary probe which should be enabled to run ndm
+  # filterconfigs contails configs of filters - in their form fo include
+  # and exclude comma separated strings
   node-disk-manager.config: |
     probeconfigs:
       - key: udev-probe
@@ -350,7 +440,7 @@ metadata:
   labels:
     name: openebs-ndm
     openebs.io/component-name: ndm
-    openebs.io/version: 1.9.0
+    openebs.io/version: 1.10.0
 spec:
   selector:
     matchLabels:
@@ -363,71 +453,94 @@ spec:
       labels:
         name: openebs-ndm
         openebs.io/component-name: ndm
-        openebs.io/version: 1.9.0
+        openebs.io/version: 1.10.0
     spec:
+      # By default the node-disk-manager will be run on all kubernetes nodes
+      # If you would like to limit this to only some nodes, say the nodes
+      # that have storage attached, you could label those node and use
+      # nodeSelector.
+      #
+      # e.g. label the storage nodes with - "openebs.io/nodegroup"="storage-node"
+      # kubectl label node <node-name> "openebs.io/nodegroup"="storage-node"
+      #nodeSelector:
+      #  "openebs.io/nodegroup": "storage-node"
       serviceAccountName: openebs-maya-operator
       hostNetwork: true
       containers:
-      - name: node-disk-manager
-        image: quay.io/openebs/node-disk-manager-amd64:v0.4.9
-        imagePullPolicy: Always
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: config
-          mountPath: /host/node-disk-manager.config
-          subPath: node-disk-manager.config
-          readOnly: true
-        - name: udev
-          mountPath: /run/udev
-        - name: procmount
-          mountPath: /host/proc
-          readOnly: true
-        - name: basepath
-          mountPath: /var/openebs/ndm
-        - name: sparsepath
-          mountPath: /var/openebs/sparse
-        env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: SPARSE_FILE_DIR
-          value: "/var/openebs/sparse"
-        - name: SPARSE_FILE_SIZE
-          value: "10737418240"
-        - name: SPARSE_FILE_COUNT
-          value: "0"
-        livenessProbe:
-          exec:
-            command:
-            - pgrep
-            - "ndm"
-          initialDelaySeconds: 30
-          periodSeconds: 60
+        - name: node-disk-manager
+          image: quay.io/openebs/node-disk-manager-amd64:0.5.0
+          args:
+            - -v=4
+          # The feature-gate is used to enable the new UUID algorithm.
+          # This is a feature currently in Alpha state
+          #  - --feature-gates="GPTBasedUUID"
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: config
+              mountPath: /host/node-disk-manager.config
+              subPath: node-disk-manager.config
+              readOnly: true
+            - name: udev
+              mountPath: /run/udev
+            - name: procmount
+              mountPath: /host/proc
+              readOnly: true
+            - name: basepath
+              mountPath: /var/openebs/ndm
+            - name: sparsepath
+              mountPath: /var/openebs/sparse
+          env:
+            # namespace in which NDM is installed will be passed to NDM Daemonset
+            # as environment variable
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # pass hostname as env variable using downward API to the NDM container
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # specify the directory where the sparse files need to be created.
+            # if not specified, then sparse files will not be created.
+            - name: SPARSE_FILE_DIR
+              value: "/var/openebs/sparse"
+            # Size(bytes) of the sparse file to be created.
+            - name: SPARSE_FILE_SIZE
+              value: "10737418240"
+            # Specify the number of sparse files to be created
+            - name: SPARSE_FILE_COUNT
+              value: "0"
+          livenessProbe:
+            exec:
+              command:
+                - pgrep
+                - "ndm"
+            initialDelaySeconds: 30
+            periodSeconds: 60
       volumes:
-      - name: config
-        configMap:
-          name: openebs-ndm-config
-      - name: udev
-        hostPath:
-          path: /run/udev
-          type: Directory
-      - name: procmount
-        hostPath:
-          path: /proc
-          type: Directory
-      - name: basepath
-        hostPath:
-          path: /var/openebs/ndm
-          type: DirectoryOrCreate
-      - name: sparsepath
-        hostPath:
-          path: /var/openebs/sparse
+        - name: config
+          configMap:
+            name: openebs-ndm-config
+        - name: udev
+          hostPath:
+            path: /run/udev
+            type: Directory
+        # mount /proc (to access mount file of process 1 of host) inside container
+        # to read mount-point of disks and partitions
+        - name: procmount
+          hostPath:
+            path: /proc
+            type: Directory
+        - name: basepath
+          hostPath:
+            path: /var/openebs/ndm
+            type: DirectoryOrCreate
+        - name: sparsepath
+          hostPath:
+            path: /var/openebs/sparse
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -437,7 +550,7 @@ metadata:
   labels:
     name: openebs-ndm-operator
     openebs.io/component-name: ndm-operator
-    openebs.io/version: 1.9.0
+    openebs.io/version: 1.10.0
 spec:
   selector:
     matchLabels:
@@ -451,12 +564,12 @@ spec:
       labels:
         name: openebs-ndm-operator
         openebs.io/component-name: ndm-operator
-        openebs.io/version: 1.9.0
+        openebs.io/version: 1.10.0
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: node-disk-operator
-          image: quay.io/openebs/node-disk-operator-amd64:v0.4.9
+          image: quay.io/openebs/node-disk-operator-amd64:0.5.0
           imagePullPolicy: Always
           readinessProbe:
             exec:
@@ -475,6 +588,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            # the service account of the ndm-operator pod
             - name: SERVICE_ACCOUNT
               valueFrom:
                 fieldRef:
@@ -482,12 +596,19 @@ spec:
             - name: OPERATOR_NAME
               value: "node-disk-operator"
             - name: CLEANUP_JOB_IMAGE
-              value: "quay.io/openebs/linux-utils:1.9.0"
+              value: "quay.io/openebs/linux-utils:1.10.0"
+            # OPENEBS_IO_INSTALL_CRD environment variable is used to enable/disable CRD installation
+            # from NDM operator. By default the CRDs will be installed
+            #- name: OPENEBS_IO_INSTALL_CRD
+            #  value: "true"
+          # Process name used for matching is limited to the 15 characters
+          # present in the pgrep output.
+          # So fullname can be used here with pgrep (cmd is < 15 chars).
           livenessProbe:
             exec:
               command:
-              - pgrep
-              - "ndo"
+                - pgrep
+                - "ndo"
             initialDelaySeconds: 30
             periodSeconds: 60
 ---
@@ -499,7 +620,7 @@ metadata:
   labels:
     app: admission-webhook
     openebs.io/component-name: admission-webhook
-    openebs.io/version: 1.9.0
+    openebs.io/version: 1.10.0
 spec:
   replicas: 1
   strategy:
@@ -513,12 +634,12 @@ spec:
       labels:
         app: admission-webhook
         openebs.io/component-name: admission-webhook
-        openebs.io/version: 1.9.0
+        openebs.io/version: 1.10.0
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: admission-webhook
-          image: quay.io/openebs/admission-server:1.9.0
+          image: quay.io/openebs/admission-server:1.10.0
           imagePullPolicy: IfNotPresent
           args:
             - -alsologtostderr
@@ -531,12 +652,18 @@ spec:
                   fieldPath: metadata.namespace
             - name: ADMISSION_WEBHOOK_NAME
               value: "openebs-admission-server"
+          # Process name used for matching is limited to the 15 characters
+          # present in the pgrep output.
+          # So fullname can't be used here with pgrep (>15 chars).A regular expression
+          # Anchor `^` : matches any string that starts with `admission-serve`
+          # `.*`: matche any string that has `admission-serve` followed by zero or more char
+          # that matches the entire command name has to specified.
           livenessProbe:
             exec:
               command:
-              - sh
-              - -c
-              - test `pgrep -c "^admission-serve.*"` = 1
+                - sh
+                - -c
+                - test `pgrep -c "^admission-serve.*"` = 1
             initialDelaySeconds: 30
             periodSeconds: 60
 ---
@@ -548,7 +675,7 @@ metadata:
   labels:
     name: openebs-localpv-provisioner
     openebs.io/component-name: openebs-localpv-provisioner
-    openebs.io/version: 1.9.0
+    openebs.io/version: 1.10.0
 spec:
   selector:
     matchLabels:
@@ -562,55 +689,289 @@ spec:
       labels:
         name: openebs-localpv-provisioner
         openebs.io/component-name: openebs-localpv-provisioner
-        openebs.io/version: 1.9.0
+        openebs.io/version: 1.10.0
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
-      - name: openebs-provisioner-hostpath
-        imagePullPolicy: Always
-        image: quay.io/openebs/provisioner-localpv:1.9.0
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: OPENEBS_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: OPENEBS_SERVICE_ACCOUNT
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.serviceAccountName
-        - name: OPENEBS_IO_ENABLE_ANALYTICS
-          value: "true"
-        - name: OPENEBS_IO_INSTALLER_TYPE
-          value: "openebs-operator"
-        - name: OPENEBS_IO_HELPER_IMAGE
-          value: "quay.io/openebs/linux-utils:1.9.0"
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - test `pgrep -c "^provisioner-loc.*"` = 1
-          initialDelaySeconds: 30
-          periodSeconds: 60
+        - name: openebs-provisioner-hostpath
+          imagePullPolicy: Always
+          image: quay.io/openebs/provisioner-localpv:1.10.0
+          env:
+            # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
+            # based on this address. This is ignored if empty.
+            # This is supported for openebs provisioner version 0.5.2 onwards
+            #- name: OPENEBS_IO_K8S_MASTER
+            #  value: "http://10.128.0.12:8080"
+            # OPENEBS_IO_KUBE_CONFIG enables openebs provisioner to connect to K8s
+            # based on this config. This is ignored if empty.
+            # This is supported for openebs provisioner version 0.5.2 onwards
+            #- name: OPENEBS_IO_KUBE_CONFIG
+            #  value: "/home/ubuntu/.kube/config"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # OPENEBS_SERVICE_ACCOUNT provides the service account of this pod as
+            # environment variable
+            - name: OPENEBS_SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: OPENEBS_IO_ENABLE_ANALYTICS
+              value: "true"
+            - name: OPENEBS_IO_INSTALLER_TYPE
+              value: "openebs-operator"
+            - name: OPENEBS_IO_HELPER_IMAGE
+              value: "quay.io/openebs/linux-utils:1.10.0"
+          # Process name used for matching is limited to the 15 characters
+          # present in the pgrep output.
+          # So fullname can't be used here with pgrep (>15 chars).A regular expression
+          # that matches the entire command name has to specified.
+          # Anchor `^` : matches any string that starts with `provisioner-loc`
+          # `.*`: matches any string that has `provisioner-loc` followed by zero or more char
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - test `pgrep -c "^provisioner-loc.*"` = 1
+            initialDelaySeconds: 30
+            periodSeconds: 60
+---
+####################################################
+###########                             ############
+###########       CSPC and CSPI         ############
+###########                             ############
+####################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: cstorpoolclusters.cstor.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: cstor.openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: cstorpoolclusters
+    # singular name to be used as an alias on the CLI and for display
+    singular: cstorpoolcluster
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CStorPoolCluster
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+      - cspc
+  additionalPrinterColumns:
+    - JSONPath: .status.healthyInstances
+      name: HealthyInstances
+      description: The number of healthy cStorPoolInstances
+      type: integer
+    - JSONPath: .status.provisionedInstances
+      name: ProvisionedInstances
+      description: The number of provisioned cStorPoolInstances
+      type: integer
+    - JSONPath: .status.desiredInstances
+      name: DesiredInstances
+      description: The number of desired cStorPoolInstances
+      type: integer
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: cstorpoolclusters.openebs.io
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: cstorpoolinstances.cstor.openebs.io
 spec:
-  group: openebs.io
-  version: v1alpha1
+  # group name to use for REST API: /apis/<group>/<version>
+  group: cstor.openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1
+  # either Namespaced or Cluster
   scope: Namespaced
   names:
-    plural: cstorpoolclusters
-    singular: cstorpoolcluster
-    kind: CStorPoolCluster
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: cstorpoolinstances
+    # singular name to be used as an alias on the CLI and for display
+    singular: cstorpoolinstance
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CStorPoolInstance
+    # shortNames allow shorter string to match your resource on the CLI
     shortNames:
-    - cspc
+      - cspi
+  additionalPrinterColumns:
+    - JSONPath: .spec.hostName
+      name: HostName
+      description: Host name where cstorpool instances scheduled
+      type: string
+    - JSONPath: .status.capacity.used
+      name: Allocated
+      description: The amount of storage space within the pool that has been physically allocated
+      type: string
+    - JSONPath: .status.capacity.free
+      name: Free
+      description: The amount of free space available in the pool
+      type: string
+    - JSONPath: .status.capacity.total
+      name: Capacity
+      description: Total size of the storage pool
+      type: string
+    - JSONPath: .status.phase
+      name: Status
+      description: Identifies the current health of the pool
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: cstorvolumes.cstor.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: cstor.openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CStorVolume
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: cstorvolumes
+    # singular name to be used as an alias on the CLI and for display
+    singular: cstorvolume
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+      - cstorvolume
+      - cv
+  additionalPrinterColumns:
+    - JSONPath: .status.phase
+      name: Status
+      description: Identifies the current health of the volume
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - JSONPath: .status.capacity
+      description: Current volume capacity
+      name: Capacity
+      type: string
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: cstorvolumeconfigs.cstor.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: cstor.openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CStorVolumeConfig
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: cstorvolumeconfigs
+    # singular name to be used as an alias on the CLI and for display
+    singular: cstorvolumeconfig
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+      - cstorvolumeconfig
+      - cvc
+  additionalPrinterColumns:
+    - JSONPath: .status.phase
+      name: Status
+      description: Identifies the volume provisioning status
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: cstorvolumepolicies.cstor.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: cstor.openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CStorVolumePolicy
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: cstorvolumepolicies
+    # singular name to be used as an alias on the CLI and for display
+    singular: cstorvolumepolicy
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+      - cstorvolumepolicies
+      - cvp
+      - policy
+  additionalPrinterColumns:
+    - JSONPath: .status.phase
+      name: Status
+      description: Identifies the state of policy
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: cstorvolumereplicas.cstor.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: cstor.openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CStorVolumeReplica
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: cstorvolumereplicas
+    # singular name to be used as an alias on the CLI and for display
+    singular: cstorvolumereplica
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+      - cvr
+  additionalPrinterColumns:
+    - JSONPath: .status.capacity.used
+      name: Used
+      description: The amount of space that is "logically" consumed by this dataset
+      type: string
+    - JSONPath: .status.capacity.total
+      name: Allocated
+      description: The amount of disk space consumed by a dataset and all its descendents
+      type: string
+    - JSONPath: .status.phase
+      name: Status
+      description: Identifies the current state of the replicas
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -620,7 +981,7 @@ metadata:
   labels:
     name: cspc-operator
     openebs.io/component-name: cspc-operator
-    openebs.io/version: 1.9.0
+    openebs.io/version: 1.10.0
 spec:
   selector:
     matchLabels:
@@ -634,34 +995,45 @@ spec:
       labels:
         name: cspc-operator
         openebs.io/component-name: cspc-operator
-        openebs.io/version: 1.9.0
+        openebs.io/version: 1.10.0
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
-      - name: cspc-operator
-        imagePullPolicy: Always
-        image: quay.io/openebs/cspc-operator:1.9.0
-        env:
-        - name: OPENEBS_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: CSPC_OPERATOR_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: OPENEBS_IO_BASE_DIR
-          value: "/var/openebs"
-        - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
-          value: "/var/openebs/sparse"
-        - name: OPENEBS_IO_CSPI_MGMT_IMAGE
-          value: "quay.io/openebs/cspi-mgmt:1.9.0"
-        - name: OPENEBS_IO_CSTOR_POOL_IMAGE
-          value: "quay.io/openebs/cstor-pool:1.9.0"
-        - name:  OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
-          value: "quay.io/openebs/m-exporter:1.9.0"
-        - name: RESYNC_INTERVAL
-          value: "30"
+        - name: cspc-operator
+          imagePullPolicy: IfNotPresent
+          image: quay.io/openebs/cspc-operator-amd64:1.10.0
+          env:
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPENEBS_SERVICEACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: CSPC_OPERATOR_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+            # Where OpenEBS can store required files. Default base path will be /var/openebs
+            - name: OPENEBS_IO_BASE_DIR
+              value: "/var/openebs"
+            # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath
+            # to be used for saving the shared content between the side cars
+            # of cstor pool pod. This ENV is also used to indicate the location
+            # of the sparse devices.
+            # The default path used is /var/openebs/sparse
+            - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+              value: "/var/openebs/sparse"
+            - name: OPENEBS_IO_CSPI_MGMT_IMAGE
+              value: "quay.io/openebs/cstor-pool-manager-amd64:1.10.0"
+            - name: OPENEBS_IO_CSTOR_POOL_IMAGE
+              value: "quay.io/openebs/cstor-pool:1.10.0"
+            - name:  OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
+              value: "quay.io/openebs/m-exporter:1.10.0"
+            - name: RESYNC_INTERVAL
+              value: "30"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -671,7 +1043,7 @@ metadata:
   labels:
     name: cvc-operator
     openebs.io/component-name: cvc-operator
-    openebs.io/version: 1.9.0
+    openebs.io/version: 1.10.0
 spec:
   selector:
     matchLabels:
@@ -685,29 +1057,78 @@ spec:
       labels:
         name: cvc-operator
         openebs.io/component-name: cvc-operator
-        openebs.io/version: 1.9.0
+        openebs.io/version: 1.10.0
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
-      - name: cvc-operator
-        imagePullPolicy: IfNotPresent
-        image: quay.io/openebs/cvc-operator:1.9.0
-        env:
-        - name: OPENEBS_IO_BASE_DIR
-          value: "/var/openebs"
-        - name: OPENEBS_IO_CSTOR_TARGET_DIR
-          value: "/var/openebs/sparse"
-        - name: OPENEBS_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
-          value: "quay.io/openebs/cstor-istgt:1.9.0"
-        - name:  OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
-          value: "quay.io/openebs/cstor-volume-mgmt:1.9.0"
-        - name:  OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "quay.io/openebs/m-exporter:1.9.0"
-
+        - name: cvc-operator
+          imagePullPolicy: IfNotPresent
+          image: quay.io/openebs/cvc-operator-amd64:1.10.0
+          env:
+            # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+            # Where OpenEBS can store required files. Default base path will be /var/openebs
+            - name: OPENEBS_IO_BASE_DIR
+              value: "/var/openebs"
+            # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
+            # that to be used for saving the core dump of cstor volume pod.
+            # The default path used is /var/openebs/sparse
+            - name: OPENEBS_IO_CSTOR_TARGET_DIR
+              value: "/var/openebs/sparse"
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPENEBS_SERVICEACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
+              value: "quay.io/openebs/cstor-istgt:1.10.0"
+            - name:  OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
+              value: "quay.io/openebs/cstor-volume-manager-amd64:1.10.0"
+            - name:  OPENEBS_IO_VOLUME_MONITOR_IMAGE
+              value: "quay.io/openebs/m-exporter:1.10.0"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-cstor-admission-server
+  namespace: openebs
+  labels:
+    app: cstor-admission-webhook
+    openebs.io/component-name: cstor-admission-webhook
+    openebs.io/version: 1.10.0
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  selector:
+    matchLabels:
+      app: cstor-admission-webhook
+  template:
+    metadata:
+      labels:
+        app: cstor-admission-webhook
+        openebs.io/component-name: cstor-admission-webhook
+        openebs.io/version: 1.10.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: admission-webhook
+          image: quay.io/openebs/cstor-webhook-amd64:1.10.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - -alsologtostderr
+            - -v=2
+            - 2>&1
+          env:
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ADMISSION_WEBHOOK_NAME
+              value: "openebs-cstor-admission-server"
 ---
 # This manifest deploys the OpenEBS CSI control plane components,
 # with associated CRs & RBAC rules. This manifest has been verified
@@ -722,7 +1143,7 @@ spec:
 #
 # For supporting a differnet OS other than the above,
 # 1) Get the list of shared object files required for iscsiadm binary in that OS version.
-# 2) Check which files are already present in the openebs-csi-plugin container present in csi node pod.
+# 2) Check which files are already present in the cstor-csi-driver container present in csi node pod.
 # 3) Mount the required missing files inside the container.
 #
 ####################################################
@@ -773,18 +1194,18 @@ status:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: csivolumes.openebs.io
+  name: cstorvolumeattachments.cstor.openebs.io
 spec:
-  group: openebs.io
-  version: v1alpha1
+  group: cstor.openebs.io
+  version: v1
   scope: Namespaced
   names:
-    plural: csivolumes
-    singular: csivolume
-    kind: CSIVolume
+    plural: cstorvolumeattachments
+    singular: cstorvolumeattachment
+    kind: CStorVolumeAttachment
     shortNames:
-      - csivolume
-      - csiv
+      - cstorvolumeattachment
+      - cva
 ---
 ##############################################
 ###########                       ############
@@ -1310,15 +1731,12 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
-  - apiGroups: ["*"]
-    resources: ["cstorvolumeclaims"]
-    verbs: ["*"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["*"]
   - apiGroups: ["*"]
-    resources: ["csivolumes", "cstorvolumes","cstorvolumeclaims"]
-    verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+    resources: ["cstorvolumeattachments", "cstorvolumes","cstorvolumeconfigs"]
+    verbs: ["*"]
 
 ---
 
@@ -1344,7 +1762,7 @@ metadata:
   labels:
     name: openebs-cstor-csi-controller
     openebs.io/component-name: openebs-cstor-csi-controller
-    openebs.io/version: 1.9.0
+    openebs.io/version: 1.10.0
 spec:
   selector:
     matchLabels:
@@ -1359,13 +1777,13 @@ spec:
         name: openebs-cstor-csi-controller
         openebs.io/component-name: openebs-cstor-csi-controller
         role: openebs-cstor-csi
-        openebs.io/version: 1.9.0
+        openebs.io/version: 1.10.0
     spec:
       priorityClassName: system-cluster-critical
       serviceAccount: openebs-cstor-csi-controller-sa
       containers:
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.1.0
+          image: quay.io/k8scsi/csi-resizer:v0.4.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -1438,7 +1856,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: openebs-csi-plugin
-          image: quay.io/openebs/cstor-csi-driver:1.9.0
+          image: quay.io/openebs/cstor-csi-driver:1.10.0
           imagePullPolicy: IfNotPresent
           env:
             - name: OPENEBS_CONTROLLER_DRIVER
@@ -1447,11 +1865,9 @@ spec:
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: OPENEBS_CSI_API_URL
               value: https://api.openebs.com/
-            - name: OPENEBS_MAPI_SVC
-              value: maya-apiserver-service
             - name: OPENEBS_NAMESPACE
               value: openebs
-          args :
+          args:
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--url=$(OPENEBS_CSI_API_URL)"
             - "--plugin=$(OPENEBS_CONTROLLER_DRIVER)"
@@ -1552,7 +1968,7 @@ rules:
     resources: ["persistentvolumes", "nodes", "services"]
     verbs: ["get", "list", "patch"]
   - apiGroups: ["*"]
-    resources: ["csivolumes", "cstorvolumes","cstorvolumeclaims"]
+    resources: ["cstorvolumeattachments", "cstorvolumes","cstorvolumeconfigs"]
     verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
 
 ---
@@ -1580,7 +1996,7 @@ metadata:
   labels:
     name: openebs-cstor-csi-node
     openebs.io/component-name: openebs-cstor-csi-node
-    openebs.io/version: 1.9.0
+    openebs.io/version: 1.10.0
 spec:
   selector:
     matchLabels:
@@ -1592,7 +2008,7 @@ spec:
         name: openebs-cstor-csi-node
         openebs.io/component-name: openebs-cstor-csi-node
         role: openebs-cstor-csi
-        openebs.io/version: 1.9.0
+        openebs.io/version: 1.10.0
     spec:
       priorityClassName: system-node-critical
       serviceAccount: openebs-cstor-csi-node-sa
@@ -1631,7 +2047,7 @@ spec:
             capabilities:
               add: ["CAP_MKNOD", "CAP_SYS_ADMIN", "SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/openebs/cstor-csi-driver:1.9.0
+          image: quay.io/openebs/cstor-csi-driver:1.10.0
           imagePullPolicy: IfNotPresent
           args:
             - "--nodeid=$(OPENEBS_NODE_ID)"
@@ -1649,8 +2065,6 @@ spec:
               value: node
             - name: OPENEBS_API_URL
               value: https://api.openebs.com/
-            - name: OPENEBS_MAPI_SVC
-              value: maya-apiserver-service
             - name: OPENEBS_NAMESPACE
               value: openebs
             - name: REMOUNT
@@ -1688,7 +2102,6 @@ spec:
           hostPath:
             path: /sbin/iscsiadm
             type: File
-
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver

--- a/templates/openebs-operator-1.5.0.yaml
+++ b/templates/openebs-operator-1.5.0.yaml
@@ -125,6 +125,14 @@ spec:
           value: "true"
         - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
           value: "false"
+        - name: OPENEBS_IO_CSTOR_TARGET_DIR
+          value: "/var/openebs/sparse"
+        - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+          value: "/var/openebs/sparse"
+        - name: OPENEBS_IO_JIVA_POOL_DIR
+          value: "/var/openebs"
+        - name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
+          value: "/var/openebs/local"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
           value: "quay.io/openebs/jiva:1.5.0"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE

--- a/templates/openebs-operator-1.6.0.yaml
+++ b/templates/openebs-operator-1.6.0.yaml
@@ -125,10 +125,18 @@ spec:
           value: "true"
         - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
           value: "false"
+        - name: OPENEBS_IO_CSTOR_TARGET_DIR
+          value: "/var/openebs/sparse"
+        - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+          value: "/var/openebs/sparse"
+        - name: OPENEBS_IO_JIVA_POOL_DIR
+          value: "/var/openebs"
+        - name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
+          value: "/var/openebs/local"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "quay.io/openebs/jiva:1.6.0"
+          value: "quay.io/openebs/jiva:1.6.2"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "quay.io/openebs/jiva:1.6.0"
+          value: "quay.io/openebs/jiva:1.6.2"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "3"
         - name: OPENEBS_IO_CSTOR_TARGET_IMAGE

--- a/templates/openebs-operator-1.7.0.yaml
+++ b/templates/openebs-operator-1.7.0.yaml
@@ -128,10 +128,20 @@ spec:
           value: "true"
         - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
           value: "false"
+        - name: OPENEBS_IO_BASE_DIR
+          value: "/var/openebs"
+        - name: OPENEBS_IO_CSTOR_TARGET_DIR
+          value: "/var/openebs/sparse"
+        - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+          value: "/var/openebs/sparse"
+        - name: OPENEBS_IO_JIVA_POOL_DIR
+          value: "/var/openebs"
+        - name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
+          value: "/var/openebs/local"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "quay.io/openebs/jiva:1.7.0"
+          value: "quay.io/openebs/jiva:1.7.1"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "quay.io/openebs/jiva:1.7.0"
+          value: "quay.io/openebs/jiva:1.7.1"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "3"
         - name: OPENEBS_IO_CSTOR_TARGET_IMAGE

--- a/templates/openebs-operator-1.8.0.yaml
+++ b/templates/openebs-operator-1.8.0.yaml
@@ -128,6 +128,16 @@ spec:
           value: "true"
         - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
           value: "false"
+        - name: OPENEBS_IO_BASE_DIR
+          value: "/var/openebs"
+        - name: OPENEBS_IO_CSTOR_TARGET_DIR
+          value: "/var/openebs/sparse"
+        - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+          value: "/var/openebs/sparse"
+        - name: OPENEBS_IO_JIVA_POOL_DIR
+          value: "/var/openebs"
+        - name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
+          value: "/var/openebs/local"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
           value: "quay.io/openebs/jiva:1.8.0"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE

--- a/types/annotations.go
+++ b/types/annotations.go
@@ -3,7 +3,7 @@ package types
 const (
 	// AnnotationPrefix is the prefix used across all
 	// the annotations supported in this project
-	AnnotationPrefix string = "dao.mayadata.io"
-	// AnnKeyOpenEBSUID is the annotation that refers to OpenEBS UID
+	AnnotationPrefix string = "openebs-upgrade.dao.mayadata.io"
+	// AnnKeyOpenEBSUID is the annotation that refers to OpenEBS UID of openebs-upgrade
 	AnnKeyOpenEBSUID string = AnnotationPrefix + "/openebs-uid"
 )

--- a/types/key.go
+++ b/types/key.go
@@ -46,8 +46,18 @@ const (
 	VolumeSnapshotClassCRDNameKey string = "volumesnapshotclasses.snapshot.storage.k8s.io"
 	// VolumeSnapshotContentCRDNameKey is the name of the VolumeSnapshotContent CRD.
 	VolumeSnapshotContentCRDNameKey string = "volumesnapshotcontents.snapshot.storage.k8s.io"
+	// CStorVolumeAttachmentsCRDNameKey is the name of the CStorVolumeAttachments CRD.
+	CStorVolumeAttachmentsCRDNameKey string = "cstorvolumeattachments.cstor.openebs.io"
 	// VolumeSnapshotCRDNameKey is the name of the VolumeSnapshot CRD.
 	VolumeSnapshotCRDNameKey string = "volumesnapshots.snapshot.storage.k8s.io"
+	// CStorVolumesCRDV1NameKey is the name of CStorVolumes V1 CRD
+	CStorVolumesCRDV1NameKey string = "cstorvolumes.cstor.openebs.io"
+	// CStorVolumeConfigsCRDV1NameKey is the name of CStorVolumeConfigs V1 CRD
+	CStorVolumeConfigsCRDV1NameKey string = "cstorvolumeconfigs.cstor.openebs.io"
+	// CStorVolumePoliciesCRDV1NameKey is the name of CStorVolumePolicies V1 CRD
+	CStorVolumePoliciesCRDV1NameKey string = "cstorvolumepolicies.cstor.openebs.io"
+	// CStorVolumeReplicasCRDV1NameKey is the name of CStorVolumeReplicas V1 CRD
+	CStorVolumeReplicasCRDV1NameKey string = "cstorvolumereplicas.cstor.openebs.io"
 	// CStorCSISnapshottterBindingNameKey is the name of the cstor csi snapshotter cluster role binding.
 	CStorCSISnapshottterBindingNameKey string = "openebs-cstor-csi-snapshotter-binding"
 	// CStorCSISnapshottterRoleNameKey is the name of the cstor csi snapshotter cluster role.
@@ -127,6 +137,7 @@ const (
 	VolumeSnapshotClassCRDManifestKey          string = VolumeSnapshotClassCRDNameKey + "_" + KindCustomResourceDefinition
 	VolumeSnapshotContentCRDManifestKey        string = VolumeSnapshotContentCRDNameKey + "_" + KindCustomResourceDefinition
 	VolumeSnapshotCRDManifestKey               string = VolumeSnapshotCRDNameKey + "_" + KindCustomResourceDefinition
+	CStorVolumeAttachmentCRDManifestKey        string = CStorVolumeAttachmentsCRDNameKey + "_" + KindCustomResourceDefinition
 	CStorCSISnapshottterBindingManifestKey     string = CStorCSISnapshottterBindingNameKey + "_" + KindClusterRoleBinding
 	CStorCSISnapshottterRoleManifestKey        string = CStorCSISnapshottterRoleNameKey + "_" + KindClusterRole
 	CStorCSIControllerSAManifestKey            string = CStorCSIControllerSANameKey + "_" + KindServiceAccount
@@ -147,15 +158,27 @@ const (
 	CVCOperatorNameKey = "cvc-operator"
 	// CSPCOperatorNameKey is the name of cspc-operator deployment.
 	CSPCOperatorNameKey = "cspc-operator"
-	// CSPCCRDNameKey is the name of CSPC CRD
-	CSPCCRDNameKey = "cstorpoolclusters.cstor.openebs.io"
+	// CSPCCRDV1NameKey is the name of CSPC V1 CRD
+	CSPCCRDV1NameKey = "cstorpoolclusters.cstor.openebs.io"
+	// CSPCCRDV1alpha1NameKey is the name of v1alpha1 CSPC CRD
+	CSPCCRDV1alpha1NameKey = "cstorpoolclusters.openebs.io"
+	// CSPICRDV1NameKey is the name of v1 CSPI CRD
+	CSPICRDV1NameKey = "cstorpoolinstances.cstor.openebs.io"
+	// CStorAdmissionServerNameKey is the name of CStor admission server
+	CStorAdmissionServerNameKey = "openebs-cstor-admission-server"
 
+	// CStorAdmissionServerManifestKey is used to get the manifest of CStor admission server
+	CStorAdmissionServerManifestKey string = CStorAdmissionServerNameKey + "_" + KindDeployment
 	// CVCOperatorManifestKey is used to get the manifest of CVC operator
 	CVCOperatorManifestKey string = CVCOperatorNameKey + "_" + KindDeployment
 	// CSPCOperatorManifestKey is used to get the manifest of CSPC operator
 	CSPCOperatorManifestKey string = CSPCOperatorNameKey + "_" + KindDeployment
-	// CSPCCRDManifestKey is used to get the manifest of CSPC CRD
-	CSPCCRDManifestKey string = CSPCCRDNameKey + "_" + KindCustomResourceDefinition
+	// CSPCCRDV1ManifestKey is used to get the manifest of CSPC CRD
+	CSPCCRDV1ManifestKey string = CSPCCRDV1NameKey + "_" + KindCustomResourceDefinition
+	// CSPCCRDV1alpha1ManifestKey is used to get the manifest of CSPC CRD v1alpha1
+	CSPCCRDV1alpha1ManifestKey string = CSPCCRDV1alpha1NameKey + "_" + KindCustomResourceDefinition
+	// CSPICRDV1ManifestKey is used to get the manifest of CSPI CRD v1
+	CSPICRDV1ManifestKey string = CSPICRDV1NameKey + "_" + KindCustomResourceDefinition
 
 	// OpenEBSVersion150 is the OpenEBS version 1.5.0
 	OpenEBSVersion150 string = "1.5.0"
@@ -169,6 +192,8 @@ const (
 	OpenEBSVersion190 string = "1.9.0"
 	// OpenEBSVersion190EE is the OpenEBS version 1.9.0-ee
 	OpenEBSVersion190EE string = "1.9.0-ee"
+	// OpenEBSVersion1100 is the OpenEBS version 1.10.0
+	OpenEBSVersion1100 string = "1.10.0"
 
 	// OSImageUbuntu1804 is the OS Image value of a Node.
 	OSImageUbuntu1804 string = "Ubuntu 18.04"
@@ -261,7 +286,13 @@ const (
 	// CSPCComponentGroupLabelValue is the value of the component-group label
 	// of CSPC components.
 	CSPCComponentGroupLabelValue string = "cspc"
+	// CSPIComponentGroupLabelValue is the value of the component-group label
+	// of CSPI components.
+	CSPIComponentGroupLabelValue string = "cspi"
 	// CVCComponentGroupLabelValue is the value of the component-group label
 	// of CVC components.
 	CVCComponentGroupLabelValue string = "cvc"
+	// CStorAdmissionServerComponentNameLabelValue is the value of the component-name label
+	// of CStor admission server component.
+	CStorAdmissionServerComponentNameLabelValue string = "cstor-admission-server"
 )

--- a/types/ndm.go
+++ b/types/ndm.go
@@ -26,6 +26,8 @@ const (
 	NDMVersion049 string = "v0.4.9"
 	// NDMVersion049EE is the enterprise NDM version v0.4.9-ee
 	NDMVersion049EE string = "v0.4.9-ee"
+	// NDMVersion050 is the NDM version 0.5.0
+	NDMVersion050 string = "0.5.0"
 	// DefaultNDMSparseSize is the default size for NDM Sparse
 	DefaultNDMSparseSize string = "10737418240"
 	// DefaultNDMSparseCount is the default count for NDM sparse

--- a/types/openebs.go
+++ b/types/openebs.go
@@ -300,14 +300,23 @@ type JivaConfig struct {
 // in the k8s cluster.
 // CSI is the configuration for deploying cstor csi operator and driver.
 type CstorConfig struct {
-	Pool         Container     `json:"pool"`
-	PoolMgmt     Container     `json:"poolMgmt"`
-	Target       Container     `json:"target"`
-	VolumeMgmt   Container     `json:"volumeMgmt"`
-	CSPIMgmt     Container     `json:"cspiMgmt"`
-	CSPCOperator *CSPCOperator `json:"cspcOperator"`
-	CVCOperator  *CVCOperator  `json:"cvcOperator"`
-	CSI          CSI           `json:"csi"`
+	Pool            Container             `json:"pool"`
+	PoolMgmt        Container             `json:"poolMgmt"`
+	Target          Container             `json:"target"`
+	VolumeMgmt      Container             `json:"volumeMgmt"`
+	VolumeManager   Container             `json:"volumeManager"`
+	CSPIMgmt        Container             `json:"cspiMgmt"`
+	CSPCOperator    *CSPCOperator         `json:"cspcOperator"`
+	CVCOperator     *CVCOperator          `json:"cvcOperator"`
+	CSI             CSI                   `json:"csi"`
+	AdmissionServer *CStorAdmissionServer `json:"admissionServer"`
+}
+
+// CStorAdmissionServer stores the configuration details of CStor admission server
+// such as if it should be installed or not, image to be used, etc.
+type CStorAdmissionServer struct {
+	Component `json:",inline"`
+	Container `json:",inline"`
 }
 
 // CSPCOperator stores the configuration details of CSPCOperator such as


### PR DESCRIPTION
- This PR adds support for OpenEBS `1.10.0` installation.

- It also adds support to update OpenEBS control-plane to `1.10.0`.

- After this PR, CSPC will be installed with `v1` schema changes.

- This PR adds some of the env fields of OpenEBS components which are configured based on the given default directory (for example, `/var/openebs`).

**NOTE for reviewer**: 

- A number of CRDs and their update functions have been added for CSPC `v1` schema related changes

- Some of the changes are introduced due to indentation also such as in file `config/metac.yaml`.

A sample OpenEBS YAML which can be used to install/update OpenEBS `1.10.0`:
```
apiVersion: dao.mayadata.io/v1alpha1
kind: OpenEBS
metadata:
  name: install-openebs-1.10.0
  namespace: openebs
spec:
  version: 1.10.0
```

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>