### PR TITLE
fix(bug): fix issue in provisioning CStor pools via CSI

### DIFF
--- a/controller/openebs/cstor.go
+++ b/controller/openebs/cstor.go
@@ -742,7 +742,7 @@ func (p *Planner) updateCVCOperator(deploy *unstructured.Unstructured) error {
 				p.ObservedOpenEBS.Spec.CstorConfig.Target.Image, "spec", "value")
 		} else if envName == "OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE" {
 			err = unstructured.SetNestedField(env.Object,
-				p.ObservedOpenEBS.Spec.CstorConfig.VolumeMgmt.Image, "spec", "value")
+				p.ObservedOpenEBS.Spec.CstorConfig.VolumeManager.Image, "spec", "value")
 		} else if envName == "OPENEBS_IO_VOLUME_MONITOR_IMAGE" {
 			err = unstructured.SetNestedField(env.Object,
 				p.ObservedOpenEBS.Spec.Policies.Monitoring.Image, "spec", "value")


### PR DESCRIPTION
The cvc-operator deployment was making use of `cstor-volume-mgmt` image instead of using `cstor-volume-manager-amd64` for OpenEBS version `1.10.0`:

`cvc-operator` deployment yaml (`wrong`)
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: cvc-operator
  namespace: openebs
  labels:
    name: cvc-operator
    openebs.io/component-name: cvc-operator
    openebs.io/version: 1.10.0-ee
spec:
  selector:
    matchLabels:
      name: cvc-operator
      openebs.io/component-name: cvc-operator
  replicas: 1
  strategy:
    type: Recreate
  template:
    metadata:
      labels:
        name: cvc-operator
        openebs.io/component-name: cvc-operator
        openebs.io/version: 1.10.0-ee
    spec:
      serviceAccountName: openebs-maya-operator
      containers:
        - name: cvc-operator
          imagePullPolicy: IfNotPresent
          image: mayadataio/cvc-operator-amd64:1.10.0-ee
          env:
            # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
            # Where OpenEBS can store required files. Default base path will be /var/openebs
            - name: OPENEBS_IO_BASE_DIR
              value: "/var/openebs"
            # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
            # that to be used for saving the core dump of cstor volume pod.
            # The default path used is /var/openebs/sparse
            - name: OPENEBS_IO_CSTOR_TARGET_DIR
              value: "/var/openebs/sparse"
            - name: OPENEBS_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: OPENEBS_SERVICEACCOUNT_NAME
              valueFrom:
                fieldRef:
                  fieldPath: spec.serviceAccountName
            - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
              value: "mayadataio/cstor-istgt:1.10.0-ee"
            - name:  **OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE**
              value: "**mayadataio/cstor-volume-mgmt:1.10.0-ee**"
            - name:  OPENEBS_IO_VOLUME_MONITOR_IMAGE
              value: "mayadataio/m-exporter:1.10.0-ee"
```

`cvc-operator` deployment yaml (`correct`)
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: cvc-operator
  namespace: openebs
  labels:
    name: cvc-operator
    openebs.io/component-name: cvc-operator
    openebs.io/version: 1.10.0-ee
spec:
  selector:
    matchLabels:
      name: cvc-operator
      openebs.io/component-name: cvc-operator
  replicas: 1
  strategy:
    type: Recreate
  template:
    metadata:
      labels:
        name: cvc-operator
        openebs.io/component-name: cvc-operator
        openebs.io/version: 1.10.0-ee
    spec:
      serviceAccountName: openebs-maya-operator
      containers:
        - name: cvc-operator
          imagePullPolicy: IfNotPresent
          image: mayadataio/cvc-operator-amd64:1.10.0-ee
          env:
            # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
            # Where OpenEBS can store required files. Default base path will be /var/openebs
            - name: OPENEBS_IO_BASE_DIR
              value: "/var/openebs"
            # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
            # that to be used for saving the core dump of cstor volume pod.
            # The default path used is /var/openebs/sparse
            - name: OPENEBS_IO_CSTOR_TARGET_DIR
              value: "/var/openebs/sparse"
            - name: OPENEBS_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: OPENEBS_SERVICEACCOUNT_NAME
              valueFrom:
                fieldRef:
                  fieldPath: spec.serviceAccountName
            - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
              value: "mayadataio/cstor-istgt:1.10.0-ee"
            - name:  **OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE**
              value: "**mayadataio/cstor-volume-manager-amd64:1.10.0-ee**"
            - name:  OPENEBS_IO_VOLUME_MONITOR_IMAGE
              value: "mayadataio/m-exporter:1.10.0-ee"
```

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>