### PR TITLE
feat(mayastor): add support for mayastor installation

### DIFF
--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -68,6 +68,18 @@ spec:
         - openebs-cstor-csi-attacher-role
         - openebs-cstor-csi-cluster-registrar-role
         - openebs-cstor-csi-registrar-role
+    - apiVersion: rbac.authorization.k8s.io/v1
+      resource: clusterrolebindings
+      updateStrategy:
+        method: InPlace
+      nameSelector:
+        - moac
+    - apiVersion: rbac.authorization.k8s.io/v1
+      resource: clusterroles
+      updateStrategy:
+        method: InPlace
+      nameSelector:
+        - moac
     - apiVersion: v1
       resource: serviceaccounts
       updateStrategy:

--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -112,6 +112,12 @@ spec:
         method: InPlace
       nameSelector:
         - cstor.csi.openebs.io
+    - apiVersion: v1
+      resource: namespaces
+      updateStrategy:
+        method: InPlace
+      nameSelector:
+        - mayastor
   hooks:
     sync:
       inline:

--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -88,6 +88,7 @@ spec:
         - openebs-maya-operator
         - openebs-cstor-csi-controller-sa
         - openebs-cstor-csi-node-sa
+        - moac
     - apiVersion: apiextensions.k8s.io/v1beta1
       resource: customresourcedefinitions
       updateStrategy:

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -237,6 +237,17 @@ func (p *Planner) removeDisabledManifests() error {
 		delete(p.ComponentManifests, types.CStorAdmissionServerManifestKey)
 	}
 
+	if *p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Enabled == false &&
+		*p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Enabled == false {
+		delete(p.ComponentManifests, types.MayastorNamespaceManifestKey)
+		delete(p.ComponentManifests, types.MoacSAManifestKey)
+		delete(p.ComponentManifests, types.MoacClusterRoleManifestKey)
+		delete(p.ComponentManifests, types.MoacClusterRoleBindingManifestKey)
+		delete(p.ComponentManifests, types.MoacDeploymentManifestKey)
+		delete(p.ComponentManifests, types.MoacServiceManifestKey)
+		delete(p.ComponentManifests, types.MayastorDaemonsetManifestKey)
+	}
+
 	if *p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Enabled == false {
 		delete(p.ComponentManifests, types.MoacSAManifestKey)
 		delete(p.ComponentManifests, types.MoacClusterRoleManifestKey)

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -414,7 +414,6 @@ func (p *Planner) getDesiredDeployment(deploy *unstructured.Unstructured) (*unst
 
 	case types.MoacDeploymentNameKey:
 		replicas = p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Replicas
-		image = p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Image
 		resources = p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Resources
 		nodeSelector = p.ObservedOpenEBS.Spec.MayastorConfig.Moac.NodeSelector
 		tolerations = p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Tolerations

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -237,29 +237,7 @@ func (p *Planner) removeDisabledManifests() error {
 		delete(p.ComponentManifests, types.CStorAdmissionServerManifestKey)
 	}
 
-	if *p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Enabled == false &&
-		*p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Enabled == false {
-		delete(p.ComponentManifests, types.MayastorNamespaceManifestKey)
-		delete(p.ComponentManifests, types.MoacSAManifestKey)
-		delete(p.ComponentManifests, types.MoacClusterRoleManifestKey)
-		delete(p.ComponentManifests, types.MoacClusterRoleBindingManifestKey)
-		delete(p.ComponentManifests, types.MoacDeploymentManifestKey)
-		delete(p.ComponentManifests, types.MoacServiceManifestKey)
-		delete(p.ComponentManifests, types.MayastorDaemonsetManifestKey)
-	}
-
-	if *p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Enabled == false {
-		delete(p.ComponentManifests, types.MoacSAManifestKey)
-		delete(p.ComponentManifests, types.MoacClusterRoleManifestKey)
-		delete(p.ComponentManifests, types.MoacClusterRoleBindingManifestKey)
-		delete(p.ComponentManifests, types.MoacDeploymentManifestKey)
-		delete(p.ComponentManifests, types.MoacServiceManifestKey)
-	}
-
-	if *p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Enabled == false {
-		delete(p.ComponentManifests, types.MayastorDaemonsetManifestKey)
-	}
-
+	p.removeMayastorManifests()
 	return nil
 }
 

--- a/controller/openebs/cstor.go
+++ b/controller/openebs/cstor.go
@@ -24,8 +24,6 @@ import (
 )
 
 const (
-	// ContainerOpenEBSCSIPluginName is the name of the container openebs csi plugin
-	ContainerOpenEBSCSIPluginName string = "openebs-csi-plugin"
 	// EnvOpenEBSNamespaceKey is the env key for openebs namespace
 	EnvOpenEBSNamespaceKey string = "OPENEBS_NAMESPACE"
 	// DefaultCSPCOperatorReplicaCount is the default replica count for
@@ -374,13 +372,7 @@ func (p *Planner) updateOpenEBSCStorCSINode(daemonset *unstructured.Unstructured
 			return err
 		}
 
-		if containerName == ContainerOpenEBSCSIPluginName {
-			// Set the image of the container.
-			err = unstructured.SetNestedField(obj.Object, p.ObservedOpenEBS.Spec.CstorConfig.CSI.CSINode.Image,
-				"spec", "image")
-			if err != nil {
-				return err
-			}
+		if containerName == types.OpenEBSCstorCSINodeContainerKey {
 			// Set the environmets of the container.
 			err = unstruct.SliceIterator(envs).ForEachUpdate(updateOpenEBSCSIPluginEnv)
 			if err != nil {
@@ -598,7 +590,7 @@ func (p *Planner) updateOpenEBSCStorCSIController(statefulset *unstructured.Unst
 			return err
 		}
 
-		if containerName == ContainerOpenEBSCSIPluginName {
+		if containerName == types.OpenEBSCstorCSINodeContainerKey {
 			// Set the image of the container.
 			err = unstructured.SetNestedField(obj.Object, p.ObservedOpenEBS.Spec.CstorConfig.CSI.CSIController.Image,
 				"spec", "image")

--- a/controller/openebs/mayastor.go
+++ b/controller/openebs/mayastor.go
@@ -1,0 +1,145 @@
+package openebs
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/openebs-upgrade/types"
+)
+
+const (
+	MayastorVersion010EE    string = "0.1.0-ee"
+	DefaultMoacReplicaCount int32  = 1
+)
+
+// supportedMayastorVersionForOpenEBSVersion stores the mapping for
+// Mayastor to OpenEBS version i.e., a Mayastor version for each of the
+// supported OpenEBS versions.
+var supportedMayastorVersionForOpenEBSVersion = map[string]string{
+	types.OpenEBSVersion1100EE: MayastorVersion010EE,
+}
+
+// Set the default values for Mayastor if not already given.
+func (p *Planner) setMayastorDefaultsIfNotSet() error {
+	if p.ObservedOpenEBS.Spec.MayastorConfig == nil {
+		p.ObservedOpenEBS.Spec.MayastorConfig = &types.MayastorConfig{}
+	}
+
+	if p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Enabled == nil {
+		p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Enabled = new(bool)
+		*p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Enabled = true
+	}
+
+	if *p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Enabled == true {
+		if p.ObservedOpenEBS.Spec.MayastorConfig.Moac.ImageTag == "" {
+			if moacVersion, exist :=
+				supportedMayastorVersionForOpenEBSVersion[p.ObservedOpenEBS.Spec.Version]; exist {
+				p.ObservedOpenEBS.Spec.MayastorConfig.Moac.ImageTag = moacVersion +
+					p.ObservedOpenEBS.Spec.ImageTagSuffix
+			} else {
+				return errors.Errorf("Failed to get moac version for the given OpenEBS version: %s",
+					p.ObservedOpenEBS.Spec.Version)
+			}
+
+			p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Image = p.ObservedOpenEBS.Spec.ImagePrefix +
+				"moac:" + p.ObservedOpenEBS.Spec.MayastorConfig.Moac.ImageTag
+
+			if p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Replicas == nil {
+				p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Replicas = new(int32)
+				*p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Replicas = DefaultMoacReplicaCount
+			}
+		}
+	}
+
+	if p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Enabled == nil {
+		p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Enabled = new(bool)
+		*p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Enabled = true
+	}
+
+	if *p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Enabled == true {
+		if p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Mayastor.ImageTag == "" {
+			if mayastorVersion, exist :=
+				supportedMayastorVersionForOpenEBSVersion[p.ObservedOpenEBS.Spec.Version]; exist {
+				p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Mayastor.ImageTag = mayastorVersion +
+					p.ObservedOpenEBS.Spec.ImageTagSuffix
+			} else {
+				return errors.Errorf("Failed to get mayastor version for the given OpenEBS version: %s",
+					p.ObservedOpenEBS.Spec.Version)
+			}
+		}
+		if p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.MayastorGRPC.ImageTag == "" {
+			if mayastorVersion, exist :=
+				supportedMayastorVersionForOpenEBSVersion[p.ObservedOpenEBS.Spec.Version]; exist {
+				p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.MayastorGRPC.ImageTag = mayastorVersion +
+					p.ObservedOpenEBS.Spec.ImageTagSuffix
+			} else {
+				return errors.Errorf("Failed to get mayastor grpc version for the given OpenEBS version: %s",
+					p.ObservedOpenEBS.Spec.Version)
+			}
+		}
+
+		p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Mayastor.Image = p.ObservedOpenEBS.Spec.ImagePrefix +
+			"mayastor:" + p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Mayastor.ImageTag
+		p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.MayastorGRPC.Image = p.ObservedOpenEBS.Spec.ImagePrefix +
+			"mayastor-grpc:" + p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.MayastorGRPC.ImageTag
+	}
+
+	return nil
+}
+
+// updateMoac updates the moac manifest as per the reconcile.ObservedOpenEBS values.
+func (p *Planner) updateMoac(deploy *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := deploy.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for moac deploy
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: mayastor
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: moac
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] = types.OpenEBSMayastorComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.MoacDeploymentNameKey
+	// set the desired labels
+	deploy.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateMoacService updates the moac service manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateMoacService(svc *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := svc.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for moac service
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: mayastor
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: moac
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.OpenEBSMayastorComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.MoacServiceNameKey
+	// set the desired labels
+	svc.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateMayastor updates the values of mayastor daemonset as per given configuration.
+func (p *Planner) updateMayastor(daemonset *unstructured.Unstructured) error {
+
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := daemonset.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for mayastor daemonset:
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: mayastor
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: mayastor
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.OpenEBSMayastorComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.MayastorDaemonsetNameKey
+	// set the desired labels
+	daemonset.SetLabels(desiredLabels)
+
+	return nil
+}

--- a/controller/openebs/mayastor.go
+++ b/controller/openebs/mayastor.go
@@ -279,3 +279,29 @@ func (p *Planner) updateMayastorNamespace(namespace *unstructured.Unstructured) 
 
 	return nil
 }
+
+// removeMayastorManifests removes the manifests of mayastor if disabled.
+func (p *Planner) removeMayastorManifests() {
+	if *p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Enabled == false &&
+		*p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Enabled == false {
+		delete(p.ComponentManifests, types.MayastorNamespaceManifestKey)
+		delete(p.ComponentManifests, types.MoacSAManifestKey)
+		delete(p.ComponentManifests, types.MoacClusterRoleManifestKey)
+		delete(p.ComponentManifests, types.MoacClusterRoleBindingManifestKey)
+		delete(p.ComponentManifests, types.MoacDeploymentManifestKey)
+		delete(p.ComponentManifests, types.MoacServiceManifestKey)
+		delete(p.ComponentManifests, types.MayastorDaemonsetManifestKey)
+	}
+
+	if *p.ObservedOpenEBS.Spec.MayastorConfig.Moac.Enabled == false {
+		delete(p.ComponentManifests, types.MoacSAManifestKey)
+		delete(p.ComponentManifests, types.MoacClusterRoleManifestKey)
+		delete(p.ComponentManifests, types.MoacClusterRoleBindingManifestKey)
+		delete(p.ComponentManifests, types.MoacDeploymentManifestKey)
+		delete(p.ComponentManifests, types.MoacServiceManifestKey)
+	}
+
+	if *p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Enabled == false {
+		delete(p.ComponentManifests, types.MayastorDaemonsetManifestKey)
+	}
+}

--- a/controller/openebs/mayastor.go
+++ b/controller/openebs/mayastor.go
@@ -102,6 +102,10 @@ func (p *Planner) updateMoac(deploy *unstructured.Unstructured) error {
 	// set the desired labels
 	deploy.SetLabels(desiredLabels)
 
+	// Overwrite the namespace to mayastor for mayastor based components.
+	// Note: mayastor based components will be installed only in mayastor namespace only.
+	deploy.SetNamespace(types.MayastorNamespaceNameKey)
+
 	return nil
 }
 
@@ -122,6 +126,10 @@ func (p *Planner) updateMoacService(svc *unstructured.Unstructured) error {
 	// set the desired labels
 	svc.SetLabels(desiredLabels)
 
+	// Overwrite the namespace to mayastor for mayastor based components.
+	// Note: mayastor based components will be installed only in mayastor namespace only.
+	svc.SetNamespace(types.MayastorNamespaceNameKey)
+
 	return nil
 }
 
@@ -141,6 +149,10 @@ func (p *Planner) updateMayastor(daemonset *unstructured.Unstructured) error {
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.MayastorDaemonsetNameKey
 	// set the desired labels
 	daemonset.SetLabels(desiredLabels)
+
+	// Overwrite the namespace to mayastor for mayastor based components.
+	// Note: mayastor based components will be installed only in mayastor namespace only.
+	daemonset.SetNamespace(types.MayastorNamespaceNameKey)
 
 	containers, err := unstruct.GetNestedSliceOrError(daemonset, "spec", "template", "spec", "containers")
 	if err != nil {
@@ -205,6 +217,32 @@ func (p *Planner) updateMayastor(daemonset *unstructured.Unstructured) error {
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// updateMayastorNamespace updates the mayastor namespace
+// structure as per the provided values otherwise default values.
+func (p *Planner) updateMayastorNamespace(namespace *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := namespace.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Set some component specific labels in order to identify specific components.
+	// These labels will be only set by openebs-upgrade and will help the end-users
+	// identify a particular or a set of OpenEBS components.
+	//
+	// Component specific labels for mayastor daemonset:
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: mayastor
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: mayastor
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.OpenEBSMayastorComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.MayastorNamespaceNameKey
+	// set the desired labels
+	namespace.SetLabels(desiredLabels)
+
+	namespace.SetName(types.MayastorNamespaceNameKey)
 
 	return nil
 }

--- a/controller/openebs/ndm.go
+++ b/controller/openebs/ndm.go
@@ -500,6 +500,18 @@ func (p *Planner) updateNDM(daemonset *unstructured.Unstructured) error {
 		if err != nil {
 			return err
 		}
+
+		// Set the resource of the containers.
+		if p.ObservedOpenEBS.Spec.NDMDaemon.Resources != nil {
+			err = unstructured.SetNestedField(obj.Object, p.ObservedOpenEBS.Spec.NDMDaemon.Resources,
+				"spec", "resources")
+		} else if p.ObservedOpenEBS.Spec.Resources != nil {
+			err = unstructured.SetNestedField(obj.Object,
+				p.ObservedOpenEBS.Spec.Resources, "spec", "resources")
+		}
+		if err != nil {
+			return err
+		}
 		return nil
 	}
 	err = unstruct.SliceIterator(containers).ForEachUpdate(updateContainer)

--- a/controller/openebs/rbac.go
+++ b/controller/openebs/rbac.go
@@ -60,6 +60,8 @@ func (p *Planner) getDesiredServiceAccount(sa *unstructured.Unstructured) (*unst
 		// Note: csi based components will be installed only in kube-system namespace only.
 		sa.SetNamespace(types.NamespaceKubeSystem)
 		err = p.updateCStorCSINodeServiceAccount(sa)
+	case types.MoacSANameKey:
+		err = p.updateMoacServiceAccount(sa)
 	}
 	if err != nil {
 		return sa, err
@@ -84,6 +86,32 @@ func (p *Planner) updateOpenEBSServiceAccount(sa *unstructured.Unstructured) err
 	// 1. openebs-upgrade.dao.mayadata.io/component-name: openebs-maya-operator
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
 		types.OpenEBSSAComponentNameLabelValue
+
+	// set the desired labels
+	sa.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateMoacServiceAccount updates the moac service account
+// structure as per the provided values otherwise default values.
+func (p *Planner) updateMoacServiceAccount(sa *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := sa.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Set some component specific labels in order to identify specific components.
+	// These labels will be only set by openebs-upgrade and will help the end-users
+	// identify a particular or a set of OpenEBS components.
+	//
+	// Component specific labels for moac service account:
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: mayastor
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: moac
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.OpenEBSMayastorComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] =
+		types.MoacSANameKey
 
 	// set the desired labels
 	sa.SetLabels(desiredLabels)
@@ -161,6 +189,8 @@ func (p *Planner) getDesiredClusterRole(cr *unstructured.Unstructured) (*unstruc
 		err = p.updateCStorCSIClusterRegistrarRole(cr)
 	case types.CStorCSIRegistrarRoleNameKey:
 		err = p.updateCStorCSIRegistrarRole(cr)
+	case types.MoacClusterRoleNameKey:
+		err = p.updateMoacClusterRole(cr)
 	}
 	if err != nil {
 		return cr, err
@@ -190,6 +220,32 @@ func (p *Planner) updateOpenEBSClusterRole(sa *unstructured.Unstructured) error 
 	// 1. openebs-upgrade.dao.mayadata.io/component-name: openebs-maya-operator
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
 		types.OpenEBSRoleComponentNameLabelValue
+
+	// set the desired labels
+	sa.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateMoacClusterRole updates the moac cluster role
+// structure as per the provided values otherwise default values.
+func (p *Planner) updateMoacClusterRole(sa *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := sa.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Set some component specific labels in order to identify specific components.
+	// These labels will be only set by openebs-upgrade and will help the end-users
+	// identify a particular or a set of OpenEBS components.
+	//
+	// Component specific labels for moac cluster role:
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: mayastor
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: moac
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.OpenEBSMayastorComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] =
+		types.MoacClusterRoleNameKey
 
 	// set the desired labels
 	sa.SetLabels(desiredLabels)
@@ -345,6 +401,8 @@ func (p *Planner) getDesiredClusterRoleBinding(crb *unstructured.Unstructured) (
 		err = p.updateCStorCSIClusterRegistrarBinding(crb)
 	case types.CStorCSIRegistrarBindingNameKey:
 		err = p.updateCStorCSIRegistrarBinding(crb)
+	case types.MoacClusterRoleBindingNameKey:
+		err = p.updateMoacClusterRoleBinding(crb)
 	}
 	if err != nil {
 		return crb, err
@@ -410,6 +468,32 @@ func (p *Planner) updateOpenEBSClusterRoleBinding(sa *unstructured.Unstructured)
 	// 1. openebs-upgrade.dao.mayadata.io/component-name: openebs-maya-operator
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
 		types.OpenEBSRoleBindingComponentNameLabelValue
+
+	// set the desired labels
+	sa.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateMoacClusterRoleBinding updates the moac cluster role
+// binding structure as per the provided values otherwise default values.
+func (p *Planner) updateMoacClusterRoleBinding(sa *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := sa.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Set some component specific labels in order to identify specific components.
+	// These labels will be only set by openebs-upgrade and will help the end-users
+	// identify a particular or a set of OpenEBS components.
+	//
+	// Component specific labels for moac cluster role binding:
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: mayastor
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: moac
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.OpenEBSMayastorComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] =
+		types.MoacClusterRoleBindingNameKey
 
 	// set the desired labels
 	sa.SetLabels(desiredLabels)

--- a/controller/openebs/reconciler.go
+++ b/controller/openebs/reconciler.go
@@ -274,6 +274,7 @@ func (p *Planner) init() error {
 		p.setNDMConfigMapDefaultsIfNotSet,
 		p.setJIVADefaultsIfNotSet,
 		p.setCStorDefaultsIfNotSet,
+		p.setMayastorDefaultsIfNotSet,
 		p.setHelperDefaultsIfNotSet,
 		p.setPoliciesDefaultsIfNotSet,
 		p.setAnalyticsDefaultsIfNotSet,

--- a/deploy/openebs.yaml
+++ b/deploy/openebs.yaml
@@ -349,6 +349,18 @@ spec:
       tolerations:
       affinity:
 
+  # mayastorConfig stores the configuration for MayaStor: CAS Data Engine.
+  mayastorConfig:
+    moac:
+      enabled:
+      imageTag:
+    mayastor:
+      enabled:
+      mayastor:
+        imageTag:
+      mayastorGrpc:
+        imageTag:
+
   # admissionServer is an implementation of kubernetes validation admission webhook.
   #
   # It is used for validating various operations before proceeding with them like

--- a/templates/openebs-operator-1.10.0-ee.yaml
+++ b/templates/openebs-operator-1.10.0-ee.yaml
@@ -2210,15 +2210,21 @@ apiVersion: apps/v1
 metadata:
   name: moac
   namespace: mayastor
+  labels:
+    openebs.io/component-name: moac
+    openebs.io/version: 1.10.0-ee
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: moac
+      openebs.io/component-name: moac
   template:
     metadata:
       labels:
         app: moac
+        openebs.io/component-name: moac
+        openebs.io/version: 1.10.0-ee
     spec:
       serviceAccount: moac
       containers:
@@ -2296,10 +2302,13 @@ metadata:
   name: mayastor
   labels:
     openebs/engine: mayastor
+    openebs.io/component-name: mayastor
+    openebs.io/version: 1.10.0-ee
 spec:
   selector:
     matchLabels:
       app: mayastor
+      openebs.io/component-name: mayastor
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -2309,6 +2318,8 @@ spec:
     metadata:
       labels:
         app: mayastor
+        openebs.io/component-name: mayastor
+        openebs.io/version: 1.10.0-ee
     spec:
       hostNetwork: true
       nodeSelector:

--- a/templates/openebs-operator-1.10.0-ee.yaml
+++ b/templates/openebs-operator-1.10.0-ee.yaml
@@ -2116,3 +2116,327 @@ spec:
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true
   attachRequired: true
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: moac
+  namespace: openebs
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: moac
+rules:
+  # must create mayastor crd if it doesn't exist
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create"]
+    # must read csi plugin info
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+    # must read mayastor pools info
+  - apiGroups: ["openebs.io"]
+    resources: ["mayastorpools"]
+    verbs: ["get", "list", "watch", "update"]
+    # must update mayastor pools status
+  - apiGroups: ["openebs.io"]
+    resources: ["mayastorpools/status"]
+    verbs: ["update"]
+    # must read/write mayastor volume resources
+  - apiGroups: ["openebs.io"]
+    resources: ["mayastorvolumes"]
+    verbs: ["get", "list", "watch", "update", "create", "delete"]
+    # must update mayastor volumes status
+  - apiGroups: ["openebs.io"]
+    resources: ["mayastorvolumes/status"]
+    verbs: ["update"]
+
+    # external provisioner & attacher
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+
+    # external provisioner
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+
+    # external attacher
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: moac
+subjects:
+  - kind: ServiceAccount
+    name: moac
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: moac
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: moac
+  namespace: openebs
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: moac
+  template:
+    metadata:
+      labels:
+        app: moac
+    spec:
+      serviceAccount: moac
+      containers:
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v1.1.1
+          args:
+            - "--v=2"
+            - "--csi-address=$(ADDRESS)"
+            - "--feature-gates=Topology=true"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v1.1.1
+          args:
+            - "--v=2"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+
+        - name: moac
+          image: mayadataio/moac:0.1.0
+          imagePullPolicy: Always
+          args:
+            - "--csi-address=$(CSI_ENDPOINT)"
+            - "--namespace=$(MY_POD_NAMESPACE)"
+            - "--port=4000"
+            - "-v"
+          env:
+            - name: CSI_ENDPOINT
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+          ports:
+            - containerPort: 4000
+              protocol: TCP
+              name: "rest-api"
+      volumes:
+        - name: socket-dir
+          emptyDir:
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: moac
+  namespace: openebs
+spec:
+  selector:
+    app: moac
+  ports:
+    - protocol: TCP
+      port: 4000
+      targetPort: 4000
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: openebs
+  name: mayastor
+  labels:
+    openebs/engine: mayastor
+spec:
+  selector:
+    matchLabels:
+      app: mayastor
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  minReadySeconds: 10
+  template:
+    metadata:
+      labels:
+        app: mayastor
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      # NOTE: Each container must have mem/cpu limits defined in order to
+      # belong to Guaranteed QoS class, hence can never get evicted in case of
+      # pressure unless they exceed those limits. limits and requests must be
+      # the same.
+      containers:
+        - name: mayastor
+          image: mayadataio/mayastor:0.1.0
+          imagePullPolicy: Always
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          args: ["-r", "/mayastor/mayastor.sock"]
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: device
+              mountPath: /dev
+            - name: dshm
+              mountPath: /dev/shm
+            - name: mayastor-dir
+              mountPath: /mayastor
+          resources:
+            limits:
+              cpu: "1"
+              memory: "500Mi"
+              hugepages-2Mi: "1Gi"
+            requests:
+              cpu: "1"
+              memory: "500Mi"
+              hugepages-2Mi: "1Gi"
+        - name: mayastor-grpc
+          image: mayadataio/mayastor-grpc:0.1.0
+          imagePullPolicy: Always
+          # we need privileged because we mount filesystems and use mknod
+          securityContext:
+            privileged: true
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: RUST_BACKTRACE
+              value: "1"
+            - name: ISCSIADM
+              value: "/bin/mayastor-iscsiadm"
+          args:
+            - "--csi-socket=/csi/csi.sock"
+            - "--mayastor-socket=/mayastor/mayastor.sock"
+            - "--node-name=$(MY_NODE_NAME)"
+            - "--address=$(MY_POD_IP)"
+            - "-v"
+          volumeMounts:
+            - name: device
+              mountPath: /dev
+            - name: host-root
+              mountPath: /host
+            - name: mayastor-dir
+              mountPath: /mayastor
+            - name: plugin-dir
+              mountPath: /csi
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+          resources:
+            limits:
+              cpu: "100m"
+              memory: "50Mi"
+            requests:
+              cpu: "100m"
+              memory: "50Mi"
+          ports:
+            - containerPort: 10124
+              protocol: TCP
+              name: mayastor
+        - name: csi-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          args:
+            - "--csi-address=/csi/csi.sock"
+            - "--kubelet-registration-path=/var/lib/kubelet/plugins/mayastor.openebs.io/csi.sock"
+          lifecycle:
+            preStop:
+              exec:
+                # this is needed in order for CSI to detect that the plugin is gone
+                command: ["/bin/sh", "-c", "rm -f /registration/io.openebs.csi-mayastor-reg.sock /csi/csi.sock"]
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+          resources:
+            limits:
+              cpu: "100m"
+              memory: "50Mi"
+            requests:
+              cpu: "100m"
+              memory: "50Mi"
+      volumes:
+        - name: device
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: host-root
+          hostPath:
+            path: /
+            type: Directory
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: "1Gi"
+        - name: hugepage
+          emptyDir:
+            medium: HugePages
+        - name: mayastor-dir
+          emptyDir: {}
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/mayastor.openebs.io/
+            type: DirectoryOrCreate
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory

--- a/templates/openebs-operator-1.10.0-ee.yaml
+++ b/templates/openebs-operator-1.10.0-ee.yaml
@@ -2119,10 +2119,15 @@ spec:
 
 ---
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: mayastor
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: moac
-  namespace: openebs
+  namespace: mayastor
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2194,7 +2199,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: moac
-    namespace: openebs
+    namespace: mayastor
 roleRef:
   kind: ClusterRole
   name: moac
@@ -2204,7 +2209,7 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: moac
-  namespace: openebs
+  namespace: mayastor
 spec:
   replicas: 1
   selector:
@@ -2274,7 +2279,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: moac
-  namespace: openebs
+  namespace: mayastor
 spec:
   selector:
     app: moac
@@ -2287,7 +2292,7 @@ spec:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  namespace: openebs
+  namespace: mayastor
   name: mayastor
   labels:
     openebs/engine: mayastor

--- a/types/key.go
+++ b/types/key.go
@@ -235,6 +235,9 @@ const (
 	// MayastorNamespaceManifestKey is used to get the manifest of mayastor namespace.
 	MayastorNamespaceManifestKey string = MayastorNamespaceNameKey + "_" + KindNamespace
 
+	// MayastorSupportedVersion is the openebs version from where mayastor is supported.
+	MayastorSupportedVersion string = "1.10.0-ee"
+
 	// OpenEBSVersion150 is the OpenEBS version 1.5.0
 	OpenEBSVersion150 string = "1.5.0"
 	// OpenEBSVersion160 is the OpenEBS version 1.6.0

--- a/types/key.go
+++ b/types/key.go
@@ -56,6 +56,16 @@ const (
 	// NDMDaemonContainerKey is the node-disk-manager container.
 	NDMDaemonContainerKey string = "node-disk-manager"
 
+	// MoacContainerKey is one of the container of moac deployment.
+	MoacContainerKey string = "moac"
+	// MayastorContainerKey is one of the container of mayastor daemonset.
+	MayastorContainerKey string = "mayastor"
+	// MayastorGRPCContainerKey is one of the container of mayastor daemonset.
+	MayastorGRPCContainerKey string = "mayastor-grpc"
+
+	// OpenEBSCstorCSINodeContainerKey is one of the container of openebs-cstor-csi-node daemonset
+	OpenEBSCstorCSINodeContainerKey string = "openebs-csi-plugin"
+
 	// CSINodeInfoCRDNameKey is the name of the CSINodeInfo CRD.
 	CSINodeInfoCRDNameKey string = "csinodeinfos.csi.storage.k8s.io"
 	// CSIVolumeCRDNameKey is the name of the CSIVolume CRD.
@@ -106,6 +116,19 @@ const (
 	CStorCSINodeNameKey string = "openebs-cstor-csi-node"
 	// CStorCSIDriverNameKey is the name of the cstor csi csidriver.
 	CStorCSIDriverNameKey string = "cstor.csi.openebs.io"
+
+	// MoacSANameKey is the name of the moac service account.
+	MoacSANameKey string = "moac"
+	// MoacClusterRoleNameKey is the name of the moac cluster role.
+	MoacClusterRoleNameKey string = "moac"
+	// MoacClusterRoleBindingNameKey is the name of the moac cluster role binding.
+	MoacClusterRoleBindingNameKey string = "moac"
+	// MoacDeploymentNameKey is the name of the moac deployment.
+	MoacDeploymentNameKey string = "moac"
+	// MoacServiceNameKey is the name of the moac service.
+	MoacServiceNameKey string = "moac"
+	// MayastorDaemonsetNameKey is the name of the mayastor daemonset
+	MayastorDaemonsetNameKey string = "mayastor"
 
 	// KindClusterRole is the k8s kind of cluster role
 	KindClusterRole string = "ClusterRole"
@@ -197,6 +220,19 @@ const (
 	CSPCCRDV1alpha1ManifestKey string = CSPCCRDV1alpha1NameKey + "_" + KindCustomResourceDefinition
 	// CSPICRDV1ManifestKey is used to get the manifest of CSPI CRD v1
 	CSPICRDV1ManifestKey string = CSPICRDV1NameKey + "_" + KindCustomResourceDefinition
+
+	// MoacSAManifestKey is used to get the manifest of moac service account.
+	MoacSAManifestKey string = MoacSANameKey + "_" + KindServiceAccount
+	// MoacClusterRoleManifestKey is used to get the manifest of moac cluster role.
+	MoacClusterRoleManifestKey string = MoacClusterRoleBindingNameKey + "_" + KindClusterRole
+	// MoacClusterRoleBindingManifestKey is used to get the manifest of moac cluster role binding.
+	MoacClusterRoleBindingManifestKey string = MoacClusterRoleBindingNameKey + "_" + KindClusterRoleBinding
+	// MoacDeploymentManifestKey is used to get the manifest of moac deployment.
+	MoacDeploymentManifestKey string = MoacDeploymentNameKey + "_" + KindDeployment
+	// MoacServiceManifestKey is used to get the manifest of moac service.
+	MoacServiceManifestKey string = MoacServiceNameKey + "_" + KindService
+	// MayastorDaemonsetManifestKey is used to get the manifest of mayastor daemonset.
+	MayastorDaemonsetManifestKey string = MayastorDaemonsetNameKey + "_" + KindDaemonSet
 
 	// OpenEBSVersion150 is the OpenEBS version 1.5.0
 	OpenEBSVersion150 string = "1.5.0"
@@ -322,6 +358,9 @@ const (
 	CStorAdmissionServerComponentNameLabelValue string = "cstor-admission-server"
 	// OpenEBSVersionLabelKey is the label that can be used to get the OpenEBS version.
 	OpenEBSVersionLabelKey string = "openebs.io/version"
+	// OpenEBSMayastorComponentGroupLabelValue is the value of the component-group label
+	// of mayastor components.
+	OpenEBSMayastorComponentGroupLabelValue string = "mayastor"
 
 	// ComponentNameLabelKey is the label key which is found in OpenEBS components.
 	// These labels and their values already exists in the OpenEBS components even

--- a/types/key.go
+++ b/types/key.go
@@ -63,9 +63,6 @@ const (
 	// MayastorGRPCContainerKey is one of the container of mayastor daemonset.
 	MayastorGRPCContainerKey string = "mayastor-grpc"
 
-	// OpenEBSCstorCSINodeContainerKey is one of the container of openebs-cstor-csi-node daemonset
-	OpenEBSCstorCSINodeContainerKey string = "openebs-csi-plugin"
-
 	// CSINodeInfoCRDNameKey is the name of the CSINodeInfo CRD.
 	CSINodeInfoCRDNameKey string = "csinodeinfos.csi.storage.k8s.io"
 	// CSIVolumeCRDNameKey is the name of the CSIVolume CRD.

--- a/types/key.go
+++ b/types/key.go
@@ -126,6 +126,8 @@ const (
 	MoacServiceNameKey string = "moac"
 	// MayastorDaemonsetNameKey is the name of the mayastor daemonset
 	MayastorDaemonsetNameKey string = "mayastor"
+	// MayastorNamespaceNameKey is the name of the mayastor namespace
+	MayastorNamespaceNameKey string = "mayastor"
 
 	// KindClusterRole is the k8s kind of cluster role
 	KindClusterRole string = "ClusterRole"
@@ -230,6 +232,8 @@ const (
 	MoacServiceManifestKey string = MoacServiceNameKey + "_" + KindService
 	// MayastorDaemonsetManifestKey is used to get the manifest of mayastor daemonset.
 	MayastorDaemonsetManifestKey string = MayastorDaemonsetNameKey + "_" + KindDaemonSet
+	// MayastorNamespaceManifestKey is used to get the manifest of mayastor namespace.
+	MayastorNamespaceManifestKey string = MayastorNamespaceNameKey + "_" + KindNamespace
 
 	// OpenEBSVersion150 is the OpenEBS version 1.5.0
 	OpenEBSVersion150 string = "1.5.0"

--- a/types/openebs.go
+++ b/types/openebs.go
@@ -96,6 +96,7 @@ type Components struct {
 	NDMConfigMap     *NDMConfigMap     `json:"ndmConfigMap"`
 	JivaConfig       *JivaConfig       `json:"jivaConfig"`
 	CstorConfig      *CstorConfig      `json:"cstorConfig"`
+	MayastorConfig   *MayastorConfig   `json:"mayastorConfig"`
 	Helper           *Helper           `json:"helper"`
 	Policies         *Policies         `json:"policies"`
 	Analytics        *Analytics        `json:"analytics"`
@@ -374,6 +375,25 @@ type CSINode struct {
 	Container `json:",inline"`
 	// ISCSIPath is the path of the iscsiadm binary.
 	ISCSIPath string `json:"iscsiPath"`
+}
+
+// MayastorConfig stores the configuration for mayastor components.
+type MayastorConfig struct {
+	Moac     Moac     `json:"moac"`
+	Mayastor Mayastor `json:"mayastor"`
+}
+
+// Mayastor is the configuration for mayastor daemonset.
+type Mayastor struct {
+	Component    `json:",inline"`
+	Mayastor     Container `json:"mayastor"`
+	MayastorGRPC Container `json:"mayastorGrpc"`
+}
+
+// Moac is the configuration for moac deployment.
+type Moac struct {
+	Component `json:",inline"`
+	Container `json:",inline"`
 }
 
 // Container stores the details of a container


### PR DESCRIPTION
This PR adds support for mayastor components installation with OpenEBS components. Mayastor installation will be supported in 1.10.0-ee openebs version i.e enterprise version.

Updated CR with this PR for the mayastor installation are shown:
```
# This configuration is for OpenEBS Installation, ControlPlaneUpgrade
# and unInstallation.
apiVersion: dao.mayadata.io/v1alpha1
kind: OpenEBS
metadata:
  name: install-openebs-1.10.0
  # Namespace i.e. the namespace where the openebs-upgrade operator and the
  # other openebs components will be installed/needs-to-be-installed.
  namespace: openebs
  labels:
    name: openebs-upgrade
spec:
  # OpenEBS Version to be installed.
  version: "1.10.0-ee"

  # mayastorConfig stores the configuration for MayaStor: CAS Data Engine.
  mayastorConfig:
    moac:
      enabled:
      imageTag:
    mayastor:
      enabled:
      mayastor:
        imageTag:
      mayastorGrpc:
        imageTag:
```
Signed-off-by: Sumit Lalwani <sumit.lalwani97@gmail.com>