### PR TITLE
enhance(install): update CSI and mayastor supported version matrix for OpenEBS 1.12.0-ee

### DIFF
--- a/controller/openebs/cstor.go
+++ b/controller/openebs/cstor.go
@@ -74,6 +74,7 @@ var SupportedCSIResizerVersionForOpenEBSVersion = map[string]string{
 	types.OpenEBSVersion1100:   types.CSIResizerVersion040,
 	types.OpenEBSVersion1100EE: types.CSIResizerVersion040,
 	types.OpenEBSVersion1110EE: types.CSIResizerVersion040,
+	types.OpenEBSVersion1120EE: types.CSIResizerVersion040,
 }
 
 // SupportedCSISnapshotterVersionForOpenEBSVersion stores the mapping for
@@ -84,6 +85,7 @@ var SupportedCSISnapshotterVersionForOpenEBSVersion = map[string]string{
 	types.OpenEBSVersion1100:   types.CSISnapshotterVersion201,
 	types.OpenEBSVersion1100EE: types.CSISnapshotterVersion201,
 	types.OpenEBSVersion1110EE: types.CSISnapshotterVersion201,
+	types.OpenEBSVersion1120EE: types.CSISnapshotterVersion201,
 }
 
 // SupportedCSISnapshotControllerVersionForOpenEBSVersion stores the mapping for
@@ -94,6 +96,7 @@ var SupportedCSISnapshotControllerVersionForOpenEBSVersion = map[string]string{
 	types.OpenEBSVersion1100:   types.CSISnapshotControllerVersion201,
 	types.OpenEBSVersion1100EE: types.CSISnapshotControllerVersion201,
 	types.OpenEBSVersion1110EE: types.CSISnapshotControllerVersion201,
+	types.OpenEBSVersion1120EE: types.CSISnapshotControllerVersion201,
 }
 
 // SupportedCSIProvisionerVersionForCSIControllerVersion stores the mapping for
@@ -104,6 +107,7 @@ var SupportedCSIProvisionerVersionForCSIControllerVersion = map[string]string{
 	types.OpenEBSVersion1100:   types.CSIProvisionerVersion150,
 	types.OpenEBSVersion1100EE: types.CSIProvisionerVersion150,
 	types.OpenEBSVersion1110EE: types.CSIProvisionerVersion160,
+	types.OpenEBSVersion1120EE: types.CSIProvisionerVersion160,
 }
 
 // SupportedCSIAttacherVersionForCSIControllerVersion stores the mapping for
@@ -114,6 +118,7 @@ var SupportedCSIAttacherVersionForCSIControllerVersion = map[string]string{
 	types.OpenEBSVersion1100:   types.CSIAttacherVersion200,
 	types.OpenEBSVersion1100EE: types.CSIAttacherVersion200,
 	types.OpenEBSVersion1110EE: types.CSIAttacherVersion200,
+	types.OpenEBSVersion1120EE: types.CSIAttacherVersion200,
 }
 
 // SupportedCSIClusterDriverRegistrarVersionForOpenEBSVersion stores the mapping for
@@ -124,6 +129,7 @@ var SupportedCSIClusterDriverRegistrarVersionForOpenEBSVersion = map[string]stri
 	types.OpenEBSVersion1100:   types.CSIClusterDriverRegistrarVersion101,
 	types.OpenEBSVersion1100EE: types.CSIClusterDriverRegistrarVersion101,
 	types.OpenEBSVersion1110EE: types.CSIClusterDriverRegistrarVersion101,
+	types.OpenEBSVersion1120EE: types.CSIClusterDriverRegistrarVersion101,
 }
 
 // SupportedCSINodeDriverRegistrarVersionForCSINodeVersion stores the mapping for
@@ -134,6 +140,7 @@ var SupportedCSINodeDriverRegistrarVersionForCSINodeVersion = map[string]string{
 	types.OpenEBSVersion1100:   types.CSINodeDriverRegistrarVersion101,
 	types.OpenEBSVersion1100EE: types.CSINodeDriverRegistrarVersion101,
 	types.OpenEBSVersion1110EE: types.CSINodeDriverRegistrarVersion101,
+	types.OpenEBSVersion1120EE: types.CSINodeDriverRegistrarVersion101,
 }
 
 // Set the default values for Cstor if not already given.

--- a/controller/openebs/mayastor.go
+++ b/controller/openebs/mayastor.go
@@ -37,6 +37,7 @@ var SupportedCSIProvisionerVersionForMOACVersion = map[string]string{
 	types.OpenEBSVersion1100:   types.CSIProvisionerVersion150,
 	types.OpenEBSVersion1100EE: types.CSIProvisionerVersion111,
 	types.OpenEBSVersion1110EE: types.CSIProvisionerVersion160,
+	types.OpenEBSVersion1120EE: types.CSIProvisionerVersion160,
 }
 
 // SupportedCSIAttacherVersionForMOACVersion stores the mapping for
@@ -45,6 +46,7 @@ var SupportedCSIAttacherVersionForMOACVersion = map[string]string{
 	types.OpenEBSVersion1100:   types.CSIAttacherVersion111,
 	types.OpenEBSVersion1100EE: types.CSIAttacherVersion111,
 	types.OpenEBSVersion1110EE: types.CSIAttacherVersion220,
+	types.OpenEBSVersion1120EE: types.CSIAttacherVersion220,
 }
 
 // SupportedCSINodeDriverRegistrarVersionForMayastorVersion stores the mapping for
@@ -52,6 +54,7 @@ var SupportedCSIAttacherVersionForMOACVersion = map[string]string{
 var SupportedCSINodeDriverRegistrarVersionForMayastorVersion = map[string]string{
 	types.OpenEBSVersion1100EE: types.CSINodeDriverRegistrarVersion110,
 	types.OpenEBSVersion1110EE: types.CSINodeDriverRegistrarVersion130,
+	types.OpenEBSVersion1120EE: types.CSINodeDriverRegistrarVersion130,
 }
 
 // Set the default values for Mayastor if not already given.


### PR DESCRIPTION
This PR updates the supported version matrix for CSI and mayastor
components for OpenEBS version 1.12.0-ee.

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>