### PR TITLE
enhance(install): remove nodeselector from Mayastor components

### DIFF
--- a/templates/openebs-operator-2.0.0-ee.yaml
+++ b/templates/openebs-operator-2.0.0-ee.yaml
@@ -4771,7 +4771,6 @@ spec:
       # To resolve services from mayastor namespace
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
-        openebs.io/engine: mayastor
         kubernetes.io/arch: amd64
       # NOTE: Each container must have mem/cpu limits defined in order to
       # belong to Guaranteed QoS class, hence can never get evicted in case of

--- a/templates/openebs-operator-2.0.0.yaml
+++ b/templates/openebs-operator-2.0.0.yaml
@@ -4771,7 +4771,6 @@ spec:
       # To resolve services from mayastor namespace
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
-        openebs.io/engine: mayastor
         kubernetes.io/arch: amd64
       # NOTE: Each container must have mem/cpu limits defined in order to
       # belong to Guaranteed QoS class, hence can never get evicted in case of


### PR DESCRIPTION
Remove nodeSelector `openebs.io/engine: mayastor` from Mayastor components so that we need not label the nodes with a new label for Mayastor.

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>