### PR TITLE
fix(bug): prevent deletion/recreation of cluster roles and cluster role bindings

### DIFF
--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -74,22 +74,12 @@ spec:
         method: InPlace
       nameSelector:
         - moac
-        - openebs-cstor-csi-attacher-binding
-        - openebs-cstor-csi-provisioner-binding
-        - openebs-cstor-csi-snapshotter-binding
-        - openebs-cstor-csi-cluster-registrar-binding
-        - openebs-cstor-csi-registrar-binding
     - apiVersion: rbac.authorization.k8s.io/v1
       resource: clusterroles
       updateStrategy:
         method: InPlace
       nameSelector:
         - moac
-        - openebs-cstor-csi-snapshotter-role
-        - openebs-cstor-csi-provisioner-role
-        - openebs-cstor-csi-attacher-role
-        - openebs-cstor-csi-cluster-registrar-role
-        - openebs-cstor-csi-registrar-role
     - apiVersion: v1
       resource: serviceaccounts
       updateStrategy:

--- a/controller/openebs/cstor.go
+++ b/controller/openebs/cstor.go
@@ -558,17 +558,22 @@ func (p *Planner) isCSISupported() (bool, error) {
 		if err != nil {
 			return false, errors.Errorf("Error comparing versions, error: %v", err)
 		}
+		if comp < 0 {
+			glog.Warningf("CSI is not supported in %s Kubernetes version. "+
+				"CSI is supported from kubernetes version %s for OpenEBS 2.0.0-ee and above.", k8sVersion, types.CSISupportedVersionFromOpenEBS200)
+			return false, nil
+		}
 	} else {
 		// compare the kubernetes version with the supported version of csi.
 		comp, err = compareVersion(k8sVersion, types.CSISupportedVersion)
 		if err != nil {
 			return false, errors.Errorf("Error comparing versions, error: %v", err)
 		}
-	}
-	if comp < 0 {
-		glog.Warningf("CSI is not supported in %s Kubernetes version. "+
-			"CSI is supported from %s Kubernetes version.", k8sVersion, types.CSISupportedVersion)
-		return false, nil
+		if comp < 0 {
+			glog.Warningf("CSI is not supported in %s Kubernetes version. "+
+				"CSI is supported from kubernetes version %s.", k8sVersion, types.CSISupportedVersion)
+			return false, nil
+		}
 	}
 
 	return true, nil

--- a/templates/openebs-operator-2.0.0-ee.yaml
+++ b/templates/openebs-operator-2.0.0-ee.yaml
@@ -4024,7 +4024,7 @@ status:
 
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-snapshotter-binding
 subjects:
@@ -4039,7 +4039,7 @@ roleRef:
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-snapshotter-role
 rules:
@@ -4095,7 +4095,7 @@ metadata:
 
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-provisioner-role
 rules:
@@ -4136,7 +4136,7 @@ rules:
 ---
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-provisioner-binding
 subjects:
@@ -4283,7 +4283,7 @@ spec:
 # Attacher must be able to work with PVs, nodes and VolumeAttachments
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-attacher-role
 rules:
@@ -4302,7 +4302,7 @@ rules:
 
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-attacher-binding
 subjects:
@@ -4317,7 +4317,7 @@ roleRef:
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-cluster-registrar-role
 rules:
@@ -4328,7 +4328,7 @@ rules:
 ---
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-cluster-registrar-binding
 subjects:
@@ -4357,7 +4357,7 @@ metadata:
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-registrar-role
 rules:
@@ -4374,7 +4374,7 @@ rules:
 ---
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-registrar-binding
 subjects:

--- a/templates/openebs-operator-2.0.0.yaml
+++ b/templates/openebs-operator-2.0.0.yaml
@@ -4024,7 +4024,7 @@ status:
 
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-snapshotter-binding
 subjects:
@@ -4039,7 +4039,7 @@ roleRef:
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-snapshotter-role
 rules:
@@ -4095,7 +4095,7 @@ metadata:
 
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-provisioner-role
 rules:
@@ -4136,7 +4136,7 @@ rules:
 ---
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-provisioner-binding
 subjects:
@@ -4283,7 +4283,7 @@ spec:
 # Attacher must be able to work with PVs, nodes and VolumeAttachments
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-attacher-role
 rules:
@@ -4302,7 +4302,7 @@ rules:
 
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-attacher-binding
 subjects:
@@ -4317,7 +4317,7 @@ roleRef:
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-cluster-registrar-role
 rules:
@@ -4328,7 +4328,7 @@ rules:
 ---
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-cluster-registrar-binding
 subjects:
@@ -4357,7 +4357,7 @@ metadata:
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-registrar-role
 rules:
@@ -4374,7 +4374,7 @@ rules:
 ---
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-csi-registrar-binding
 subjects:


### PR DESCRIPTION
This PR fixes the bug where the cluster roles and cluster role bindings were
getting deleted and recreated on every reconciliation from OpenEBS version
2.0.0-ee-RC1 onwards.

**What happened?**
The CSI components related cluster roles and cluster role bindings were getting deleted and recreated on every reconciliation from OpenEBS version 2.0.0-ee-RC1 onwards due to which one of the containers of **openebs-csi-controller** was restarting again and again.

**Solution/Fix:**
This was happening since we had started making use of apiVersion: rbac.authorization.k8s.io/v1 for the cluster roles and cluster role bindings of CSI, we have been making use of apiVersion: rbac.authorization.k8s.io/v1beta1 in the previous versions for these roles and bindings.
Due to the above change, in order to maintain backward compatibility, we were mentioning both the apiVersion in the metac config YAML. The expectation from this was that we would be getting the ones in apiVersion: rbac.authorization.k8s.io/v1 in only this category of attachments and the ones in apiVersion: rbac.authorization.k8s.io/v1beta1 in this category but what started happening is that these roles and role bindings started to come twice as attachments in both the category.
Since these were coming as observed resources in both categories but we were sending them in desired resources only once, metac was deleting it and recreating it.

In order to avoid this scenario, we are only making use of apiVersion: rbac.authorization.k8s.io/v1beta1 as of now for all the cluster roles and cluster role bindings.

Issue link: https://github.com/mayadata-io/oep/issues/285

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>