### PR TITLE
refactor(adopt): support openebs-cstor-admission-server adoption

### DIFF
--- a/controller/adoptopenebs/identifier.go
+++ b/controller/adoptopenebs/identifier.go
@@ -113,6 +113,12 @@ func (oi *OpenEBSIdentifier) identifyOpenEBSComponentUsingLabels() (string, erro
 		componentType = types.CVCOperatorNameKey
 	case types.CVCOperatorServiceComponentNameLabelValue:
 		componentType = types.CVCOperatorServiceNameKey
+	case types.CStorAdmissionServerComponentNameLabelValue:
+		// same set of labels can be found for deployment and svc both but we
+		// are interested in deployment only.
+		if oi.Object.GetKind() == types.KindDeployment {
+			componentType = types.CStorAdmissionServerNameKey
+		}
 	case types.CStorCSINodeComponentNameLabelValue:
 		componentType = types.CStorCSINodeNameKey
 	case types.CStorCSIControllerComponentNameLabelValue:

--- a/controller/openebs/cstor.go
+++ b/controller/openebs/cstor.go
@@ -302,6 +302,11 @@ func (p *Planner) setCStorDefaultsIfNotSet() error {
 		p.ObservedOpenEBS.Spec.CstorConfig.AdmissionServer.Enabled = new(bool)
 		*p.ObservedOpenEBS.Spec.CstorConfig.AdmissionServer.Enabled = true
 	}
+
+	// set the name with which openebs-cstor-admission-server will be deployed
+	if len(p.ObservedOpenEBS.Spec.CstorConfig.AdmissionServer.Name) == 0 {
+		p.ObservedOpenEBS.Spec.CstorConfig.AdmissionServer.Name = types.CStorAdmissionServerNameKey
+	}
 	// form the CStor admission server image
 	if p.ObservedOpenEBS.Spec.CstorConfig.AdmissionServer.ImageTag == "" {
 		p.ObservedOpenEBS.Spec.CstorConfig.AdmissionServer.ImageTag = p.ObservedOpenEBS.Spec.Version +
@@ -1316,13 +1321,14 @@ func (p *Planner) updateCVCOperator(deploy *unstructured.Unstructured) error {
 
 // updateCStorAdmissionServer updates the CStorAdmissionServer manifest as per the reconcile.ObservedOpenEBS values.
 func (p *Planner) updateCStorAdmissionServer(deploy *unstructured.Unstructured) error {
+	deploy.SetName(p.ObservedOpenEBS.Spec.CstorConfig.AdmissionServer.Name)
 	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
 	desiredLabels := deploy.GetLabels()
 	if desiredLabels == nil {
 		desiredLabels = make(map[string]string, 0)
 	}
 	// Component specific labels for CStor admissionServer deploy
-	// 1. openebs-upgrade.dao.mayadata.io/component-name: cstor-admission-server
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: cstor-admission-webhook
 	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.CStorAdmissionServerComponentNameLabelValue
 	// set the desired labels
 	deploy.SetLabels(desiredLabels)

--- a/types/key.go
+++ b/types/key.go
@@ -411,7 +411,7 @@ const (
 	CVCComponentGroupLabelValue string = "cvc"
 	// CStorAdmissionServerComponentNameLabelValue is the value of the component-name label
 	// of CStor admission server component.
-	CStorAdmissionServerComponentNameLabelValue string = "cstor-admission-server"
+	CStorAdmissionServerComponentNameLabelValue string = "cstor-admission-webhook"
 	// OpenEBSVersionLabelKey is the label that can be used to get the OpenEBS version.
 	OpenEBSVersionLabelKey string = "openebs.io/version"
 	// OpenEBSMayastorComponentGroupLabelValue is the value of the component-group label


### PR DESCRIPTION
This PR adds the logic to support adoption of openebs-cstor-admission-server
component also.
Now the openebs-cstor-admission-server can also be adopted and upgraded going further.

Issue link: https://github.com/mayadata-io/oep/issues/292

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>