### PR TITLE
fix(bug): fix nats image installation issue

### DIFF
--- a/controller/openebs/mayastor.go
+++ b/controller/openebs/mayastor.go
@@ -18,7 +18,7 @@ const (
 	MayastorCSIVersion030    string = "v0.3.0"
 	MayastorCSIVersion030EE  string = "v0.3.0-ee"
 	NATSVersion21Alpine311   string = "2.1-alpine3.11"
-	NATSVersion21Alpine311EE string = "2.1-alpine3.11-ee"
+	NATSVersion21Alpine311EE string = "2.1-alpine3.11"
 	DefaultMoacReplicaCount  int32  = 1
 	DefaultNATSReplicaCount  int32  = 1
 )


### PR DESCRIPTION
Removed the `-ee` suffix from the nats image as it is a public image and not one being built from `mayadataio/` repository.

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>