### PR TITLE
fix(bug): fix upgrade issue after adoption

### DIFF
--- a/controller/adoptopenebs/apiserver.go
+++ b/controller/adoptopenebs/apiserver.go
@@ -7,6 +7,7 @@ import (
 	"mayadata.io/openebs-upgrade/unstruct"
 	"mayadata.io/openebs-upgrade/util"
 	"strconv"
+	"strings"
 )
 
 // formMayaAPIServerConfig forms the desired OpenEBS CR config for MayaAPIServer.
@@ -100,7 +101,7 @@ func (p *Planner) formMayaAPIServerConfig(mayaAPIServer *unstructured.Unstructur
 		if err != nil {
 			return err
 		}
-		if containerName == "maya-apiserver" {
+		if containerName == "maya-apiserver" || strings.Contains(containerName, "apiserver") {
 			mayaAPIServerDetails[types.KeyResources], _, err = unstructured.NestedMap(obj.Object,
 				"spec", "resources")
 			if err != nil {
@@ -117,6 +118,9 @@ func (p *Planner) formMayaAPIServerConfig(mayaAPIServer *unstructured.Unstructur
 			}
 			if imageTag != p.OpenEBSVersion {
 				mayaAPIServerDetails[types.KeyImageTag] = imageTag
+			}
+			if containerName != "maya-apiserver" {
+				mayaAPIServerDetails[types.KeyContainerName] = containerName
 			}
 			// get the environmets of the container.
 			err = unstruct.SliceIterator(envs).ForEach(getMayaAPIServerENVs)

--- a/controller/adoptopenebs/common.go
+++ b/controller/adoptopenebs/common.go
@@ -41,6 +41,8 @@ func (p *Planner) formComponentOpenEBSConfig(component *unstructured.Unstructure
 		err = p.formCstorCSIController(component)
 	case types.CStorAdmissionServerNameKey:
 		err = p.formCstorAdmissionServer(component)
+	case types.CStorCSIISCSIADMConfigmapNameKey:
+		err = p.formCStorCSIISCSIADMConfigmapConfig(component)
 	case types.MoacDeploymentNameKey:
 		err = p.formMayastorMOACConfig(component)
 	case types.MayastorMOACSVCNameKey:
@@ -120,5 +122,6 @@ func (p *Planner) getResourceCommonDetails(resource *unstructured.Unstructured,
 	if err != nil {
 		return resourceDetails, err
 	}
+
 	return resourceDetails, nil
 }

--- a/controller/adoptopenebs/cstor.go
+++ b/controller/adoptopenebs/cstor.go
@@ -457,3 +457,32 @@ func (p *Planner) formCStorConfig() error {
 
 	return nil
 }
+
+// formCStorCSIISCSIADMConfigmapConfig forms the desired OpenEBS CR config for openebs-cstor-csi-iscsiadm
+// configmap.
+func (p *Planner) formCStorCSIISCSIADMConfigmapConfig(iscsiadmConfigmap *unstructured.Unstructured) error {
+	ISCSIADMConfigmapConfig := make(map[string]interface{}, 0)
+	// CstorCSIISCSIADM config is part of CStor config.
+	cstorConfig := &unstructured.Unstructured{
+		Object: make(map[string]interface{}, 0),
+	}
+	csiConfig := make(map[string]interface{}, 0)
+	if p.CstorConfig != nil {
+		cstorConfig = p.CstorConfig
+		csi, exist, err := unstructured.NestedMap(cstorConfig.Object, "csi")
+		if err != nil {
+			return errors.Errorf(
+				"Error forming CStorCSIISCSIADMConfig: error fetching CSI config from cstorConfig: %+v", err)
+		}
+		if exist {
+			csiConfig = csi
+		}
+	}
+	// set the ISCSIADMConfigmapConfig values wrt ISCSIADMConfigmap field
+	ISCSIADMConfigmapConfig[types.KeyName] = iscsiadmConfigmap.GetName()
+	csiConfig["iscsiadmConfigmap"] = ISCSIADMConfigmapConfig
+	cstorConfig.Object["csi"] = csiConfig
+	p.CstorConfig = cstorConfig
+
+	return nil
+}

--- a/controller/adoptopenebs/identifier.go
+++ b/controller/adoptopenebs/identifier.go
@@ -59,6 +59,7 @@ func (oi *OpenEBSIdentifier) IdentifyOpenEBSComponentType() (string, error) {
 		// All the functions will be run one by one until one of the functions
 		// succeed in identifying the type of OpenEBS component here or all fails.
 		oi.identifyOpenEBSComponentUsingLabels,
+		oi.identifyOpenEBSComponentUsingName,
 	}
 	for _, fn := range initFuncs {
 		componentType, err := fn()
@@ -70,6 +71,19 @@ func (oi *OpenEBSIdentifier) IdentifyOpenEBSComponentType() (string, error) {
 		}
 	}
 	return "", nil
+}
+
+// identifyOpenEBSComponentUsingName tries to identify the type of OpenEBS component
+// using its name defined in the .metadata.name.
+func (oi *OpenEBSIdentifier) identifyOpenEBSComponentUsingName() (string, error) {
+	var (
+		componentType string
+	)
+	switch oi.Object.GetName() {
+	case types.CStorCSIISCSIADMConfigmapNameKey:
+		componentType = types.CStorCSIISCSIADMConfigmapNameKey
+	}
+	return componentType, nil
 }
 
 // identifyOpenEBSComponentUsingLabels tries to identify the type of OpenEBS component
@@ -123,6 +137,8 @@ func (oi *OpenEBSIdentifier) identifyOpenEBSComponentUsingLabels() (string, erro
 		componentType = types.CStorCSINodeNameKey
 	case types.CStorCSIControllerComponentNameLabelValue:
 		componentType = types.CStorCSIControllerNameKey
+	case types.CStorCSIISCSIADMConfigmapComponentNameLabelValue:
+		componentType = types.CStorCSIISCSIADMConfigmapNameKey
 	case types.MayastorMOACComponentNameLabelValue:
 		componentType = types.MoacDeploymentNameKey
 	case types.MayastorMOACServiceComponentNameLabelValue:

--- a/controller/adoptopenebs/reconciler.go
+++ b/controller/adoptopenebs/reconciler.go
@@ -260,21 +260,22 @@ type Planner struct {
 	HelperImageTag             string
 	EnableAnalytics            bool
 
-	Resources              *unstructured.Unstructured
-	APIServerConfig        *unstructured.Unstructured
-	ProvisionerConfig      *unstructured.Unstructured
-	LocalProvisionerConfig *unstructured.Unstructured
-	AdmissionServerConfig  *unstructured.Unstructured
-	SnapshotOperatorConfig *unstructured.Unstructured
-	NDMDaemonConfig        *unstructured.Unstructured
-	NDMOperatorConfig      *unstructured.Unstructured
-	NDMConfigMapConfig     *unstructured.Unstructured
-	JivaConfig             *unstructured.Unstructured
-	CstorConfig            *unstructured.Unstructured
-	HelperConfig           *unstructured.Unstructured
-	PoliciesConfig         *unstructured.Unstructured
-	AnalyticsConfig        *unstructured.Unstructured
-	MayastorConfig         *unstructured.Unstructured
+	Resources               *unstructured.Unstructured
+	APIServerConfig         *unstructured.Unstructured
+	ProvisionerConfig       *unstructured.Unstructured
+	LocalProvisionerConfig  *unstructured.Unstructured
+	AdmissionServerConfig   *unstructured.Unstructured
+	SnapshotOperatorConfig  *unstructured.Unstructured
+	NDMDaemonConfig         *unstructured.Unstructured
+	NDMOperatorConfig       *unstructured.Unstructured
+	NDMConfigMapConfig      *unstructured.Unstructured
+	JivaConfig              *unstructured.Unstructured
+	CstorConfig             *unstructured.Unstructured
+	ISCSIADMConfigMapConfig *unstructured.Unstructured
+	HelperConfig            *unstructured.Unstructured
+	PoliciesConfig          *unstructured.Unstructured
+	AnalyticsConfig         *unstructured.Unstructured
+	MayastorConfig          *unstructured.Unstructured
 }
 
 // NewReconciler returns a new instance of Reconciler

--- a/controller/openebs/mayastor.go
+++ b/controller/openebs/mayastor.go
@@ -792,3 +792,58 @@ func (p *Planner) updateMayastorCSI(daemonset *unstructured.Unstructured) error 
 
 	return nil
 }
+
+func (p *Planner) fillMayastorMOACExistingValues(observedComponentDetails ObservedComponentDesiredDetails) error {
+	var (
+		containerName string
+		err           error
+	)
+	p.ObservedOpenEBS.Spec.MayastorConfig.Moac.MatchLabels = observedComponentDetails.MatchLabels
+	p.ObservedOpenEBS.Spec.MayastorConfig.Moac.PodTemplateLabels = observedComponentDetails.PodTemplateLabels
+	if len(p.ObservedOpenEBS.Spec.MayastorConfig.Moac.ContainerName) > 0 {
+		containerName = p.ObservedOpenEBS.Spec.MayastorConfig.Moac.ContainerName
+	} else {
+		containerName = types.MoacContainerKey
+	}
+	p.ObservedOpenEBS.Spec.MayastorConfig.Moac.ENV, err = fetchExistingContainerEnvs(
+		observedComponentDetails.Containers, containerName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Planner) fillMayastorMayastorExistingValues(observedComponentDetails ObservedComponentDesiredDetails) error {
+	var (
+		containerName string
+		err           error
+	)
+	p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.MatchLabels = observedComponentDetails.MatchLabels
+	p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.PodTemplateLabels = observedComponentDetails.PodTemplateLabels
+	// update for mayastor container
+	if len(p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Mayastor.ContainerName) > 0 {
+		containerName = p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Mayastor.ContainerName
+	} else {
+		containerName = types.MayastorContainerKey
+	}
+	p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.Mayastor.ENV, err = fetchExistingContainerEnvs(
+		observedComponentDetails.Containers, containerName)
+	if err != nil {
+		return err
+	}
+
+	// update for mayastor-grpc
+	if len(p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.MayastorGRPC.ContainerName) > 0 {
+		containerName = p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.MayastorGRPC.ContainerName
+	} else {
+		containerName = types.MayastorGRPCContainerKey
+	}
+	p.ObservedOpenEBS.Spec.MayastorConfig.Mayastor.MayastorGRPC.ENV, err = fetchExistingContainerEnvs(
+		observedComponentDetails.Containers, containerName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/controller/openebs/reconciler.go
+++ b/controller/openebs/reconciler.go
@@ -290,6 +290,7 @@ func (p *Planner) init() error {
 		p.setHelperDefaultsIfNotSet,
 		p.setPoliciesDefaultsIfNotSet,
 		p.setAnalyticsDefaultsIfNotSet,
+		p.getDesiredValuesFromObservedResources,
 		p.removeDisabledManifests,
 		p.getDesiredManifests,
 	}

--- a/templates/openebs-operator-1.10.0-ee.yaml
+++ b/templates/openebs-operator-1.10.0-ee.yaml
@@ -200,7 +200,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
           # OPENEBS_IO_ANALYTICS_PING_INTERVAL can be used to specify the duration (in hours)
           # for periodic ping events sent to Google Analytics.
           # Default is 24h.
@@ -724,7 +724,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
             - name: OPENEBS_IO_HELPER_IMAGE
               value: "mayadataio/linux-utils:1.10.0-ee"
           # Process name used for matching is limited to the 15 characters
@@ -2108,10 +2108,6 @@ kind: CSIDriver
 metadata:
   name: cstor.csi.openebs.io
 spec:
-  # Supports persistent and ephemeral inline volumes.
-  volumeLifecycleModes:
-    - Persistent
-    - Ephemeral
   # To determine at runtime which mode a volume uses, pod info and its
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true

--- a/templates/openebs-operator-1.10.0.yaml
+++ b/templates/openebs-operator-1.10.0.yaml
@@ -200,7 +200,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
           # OPENEBS_IO_ANALYTICS_PING_INTERVAL can be used to specify the duration (in hours)
           # for periodic ping events sent to Google Analytics.
           # Default is 24h.
@@ -724,7 +724,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
             - name: OPENEBS_IO_HELPER_IMAGE
               value: "quay.io/openebs/linux-utils:1.10.0"
           # Process name used for matching is limited to the 15 characters
@@ -2108,10 +2108,6 @@ kind: CSIDriver
 metadata:
   name: cstor.csi.openebs.io
 spec:
-  # Supports persistent and ephemeral inline volumes.
-  volumeLifecycleModes:
-    - Persistent
-    - Ephemeral
   # To determine at runtime which mode a volume uses, pod info and its
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true

--- a/templates/openebs-operator-1.11.0-ee.yaml
+++ b/templates/openebs-operator-1.11.0-ee.yaml
@@ -200,7 +200,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
           # OPENEBS_IO_ANALYTICS_PING_INTERVAL can be used to specify the duration (in hours)
           # for periodic ping events sent to Google Analytics.
           # Default is 24h.
@@ -724,7 +724,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
             - name: OPENEBS_IO_HELPER_IMAGE
               value: "mayadataio/linux-utils:1.11.0-ee"
           # Process name used for matching is limited to the 15 characters
@@ -2231,10 +2231,6 @@ kind: CSIDriver
 metadata:
   name: cstor.csi.openebs.io
 spec:
-  # Supports persistent and ephemeral inline volumes.
-  volumeLifecycleModes:
-    - Persistent
-    - Ephemeral
   # To determine at runtime which mode a volume uses, pod info and its
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true

--- a/templates/openebs-operator-1.11.0.yaml
+++ b/templates/openebs-operator-1.11.0.yaml
@@ -200,7 +200,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
           # OPENEBS_IO_ANALYTICS_PING_INTERVAL can be used to specify the duration (in hours)
           # for periodic ping events sent to Google Analytics.
           # Default is 24h.
@@ -724,7 +724,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
             - name: OPENEBS_IO_HELPER_IMAGE
               value: "quay.io/openebs/linux-utils:1.11.0"
           # Process name used for matching is limited to the 15 characters
@@ -2231,10 +2231,6 @@ kind: CSIDriver
 metadata:
   name: cstor.csi.openebs.io
 spec:
-  # Supports persistent and ephemeral inline volumes.
-  volumeLifecycleModes:
-    - Persistent
-    - Ephemeral
   # To determine at runtime which mode a volume uses, pod info and its
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true

--- a/templates/openebs-operator-1.12.0-ee.yaml
+++ b/templates/openebs-operator-1.12.0-ee.yaml
@@ -200,7 +200,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
           # OPENEBS_IO_ANALYTICS_PING_INTERVAL can be used to specify the duration (in hours)
           # for periodic ping events sent to Google Analytics.
           # Default is 24h.
@@ -726,7 +726,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
             - name: OPENEBS_IO_HELPER_IMAGE
               value: "mayadataio/linux-utils:1.12.0-ee"
           # Process name used for matching is limited to the 15 characters
@@ -2247,10 +2247,6 @@ kind: CSIDriver
 metadata:
   name: cstor.csi.openebs.io
 spec:
-  # Supports persistent and ephemeral inline volumes.
-  volumeLifecycleModes:
-    - Persistent
-    - Ephemeral
   # To determine at runtime which mode a volume uses, pod info and its
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true

--- a/templates/openebs-operator-1.12.0.yaml
+++ b/templates/openebs-operator-1.12.0.yaml
@@ -200,7 +200,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
           # OPENEBS_IO_ANALYTICS_PING_INTERVAL can be used to specify the duration (in hours)
           # for periodic ping events sent to Google Analytics.
           # Default is 24h.
@@ -726,7 +726,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
             - name: OPENEBS_IO_HELPER_IMAGE
               value: "openebs/linux-utils:1.12.0"
           # Process name used for matching is limited to the 15 characters
@@ -2247,10 +2247,6 @@ kind: CSIDriver
 metadata:
   name: cstor.csi.openebs.io
 spec:
-  # Supports persistent and ephemeral inline volumes.
-  volumeLifecycleModes:
-    - Persistent
-    - Ephemeral
   # To determine at runtime which mode a volume uses, pod info and its
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true

--- a/templates/openebs-operator-1.5.0.yaml
+++ b/templates/openebs-operator-1.5.0.yaml
@@ -156,7 +156,7 @@ spec:
         - name: OPENEBS_IO_ENABLE_ANALYTICS
           value: "true"
         - name: OPENEBS_IO_INSTALLER_TYPE
-          value: "openebs-operator"
+          value: "openebs-enterprise-operator"
         livenessProbe:
           exec:
             command:
@@ -550,7 +550,7 @@ spec:
         - name: OPENEBS_IO_ENABLE_ANALYTICS
           value: "true"
         - name: OPENEBS_IO_INSTALLER_TYPE
-          value: "openebs-operator"
+          value: "openebs-enterprise-operator"
         - name: OPENEBS_IO_HELPER_IMAGE
           value: "quay.io/openebs/linux-utils:1.5.0"
         livenessProbe:

--- a/templates/openebs-operator-1.6.0.yaml
+++ b/templates/openebs-operator-1.6.0.yaml
@@ -156,7 +156,7 @@ spec:
         - name: OPENEBS_IO_ENABLE_ANALYTICS
           value: "true"
         - name: OPENEBS_IO_INSTALLER_TYPE
-          value: "openebs-operator"
+          value: "openebs-enterprise-operator"
         livenessProbe:
           exec:
             command:
@@ -550,7 +550,7 @@ spec:
         - name: OPENEBS_IO_ENABLE_ANALYTICS
           value: "true"
         - name: OPENEBS_IO_INSTALLER_TYPE
-          value: "openebs-operator"
+          value: "openebs-enterprise-operator"
         - name: OPENEBS_IO_HELPER_IMAGE
           value: "quay.io/openebs/linux-utils:1.6.0"
         livenessProbe:

--- a/templates/openebs-operator-1.7.0.yaml
+++ b/templates/openebs-operator-1.7.0.yaml
@@ -161,7 +161,7 @@ spec:
         - name: OPENEBS_IO_ENABLE_ANALYTICS
           value: "true"
         - name: OPENEBS_IO_INSTALLER_TYPE
-          value: "openebs-operator"
+          value: "openebs-enterprise-operator"
         livenessProbe:
           exec:
             command:
@@ -561,7 +561,7 @@ spec:
         - name: OPENEBS_IO_ENABLE_ANALYTICS
           value: "true"
         - name: OPENEBS_IO_INSTALLER_TYPE
-          value: "openebs-operator"
+          value: "openebs-enterprise-operator"
         - name: OPENEBS_IO_HELPER_IMAGE
           value: "quay.io/openebs/linux-utils:1.7.0"
         livenessProbe:

--- a/templates/openebs-operator-1.8.0.yaml
+++ b/templates/openebs-operator-1.8.0.yaml
@@ -159,7 +159,7 @@ spec:
         - name: OPENEBS_IO_ENABLE_ANALYTICS
           value: "true"
         - name: OPENEBS_IO_INSTALLER_TYPE
-          value: "openebs-operator"
+          value: "openebs-enterprise-operator"
         livenessProbe:
           exec:
             command:
@@ -559,7 +559,7 @@ spec:
         - name: OPENEBS_IO_ENABLE_ANALYTICS
           value: "true"
         - name: OPENEBS_IO_INSTALLER_TYPE
-          value: "openebs-operator"
+          value: "openebs-enterprise-operator"
         - name: OPENEBS_IO_HELPER_IMAGE
           value: "quay.io/openebs/linux-utils:1.8.0"
         livenessProbe:

--- a/templates/openebs-operator-1.9.0-ee.yaml
+++ b/templates/openebs-operator-1.9.0-ee.yaml
@@ -155,7 +155,7 @@ spec:
         - name: OPENEBS_IO_ENABLE_ANALYTICS
           value: "true"
         - name: OPENEBS_IO_INSTALLER_TYPE
-          value: "openebs-operator"
+          value: "openebs-enterprise-operator"
         livenessProbe:
           exec:
             command:
@@ -575,7 +575,7 @@ spec:
         - name: OPENEBS_IO_ENABLE_ANALYTICS
           value: "true"
         - name: OPENEBS_IO_INSTALLER_TYPE
-          value: "openebs-operator"
+          value: "openebs-enterprise-operator"
         - name: OPENEBS_IO_HELPER_IMAGE
           value: "mayadataio/linux-utils:1.9.0-ee"
         livenessProbe:
@@ -1685,10 +1685,6 @@ kind: CSIDriver
 metadata:
   name: cstor.csi.openebs.io
 spec:
-  # Supports persistent and ephemeral inline volumes.
-  volumeLifecycleModes:
-    - Persistent
-    - Ephemeral
   # To determine at runtime which mode a volume uses, pod info and its
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true

--- a/templates/openebs-operator-1.9.0.yaml
+++ b/templates/openebs-operator-1.9.0.yaml
@@ -165,7 +165,7 @@ spec:
         - name: OPENEBS_IO_ENABLE_ANALYTICS
           value: "true"
         - name: OPENEBS_IO_INSTALLER_TYPE
-          value: "openebs-operator"
+          value: "openebs-enterprise-operator"
         livenessProbe:
           exec:
             command:
@@ -585,7 +585,7 @@ spec:
         - name: OPENEBS_IO_ENABLE_ANALYTICS
           value: "true"
         - name: OPENEBS_IO_INSTALLER_TYPE
-          value: "openebs-operator"
+          value: "openebs-enterprise-operator"
         - name: OPENEBS_IO_HELPER_IMAGE
           value: "quay.io/openebs/linux-utils:1.9.0"
         livenessProbe:
@@ -1695,10 +1695,6 @@ kind: CSIDriver
 metadata:
   name: cstor.csi.openebs.io
 spec:
-  # Supports persistent and ephemeral inline volumes.
-  volumeLifecycleModes:
-    - Persistent
-    - Ephemeral
   # To determine at runtime which mode a volume uses, pod info and its
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true

--- a/templates/openebs-operator-2.0.0-ee.yaml
+++ b/templates/openebs-operator-2.0.0-ee.yaml
@@ -200,7 +200,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
           # OPENEBS_IO_ANALYTICS_PING_INTERVAL can be used to specify the duration (in hours)
           # for periodic ping events sent to Google Analytics.
           # Default is 24h.
@@ -283,6 +283,7 @@ spec:
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
+                  apiVersion: v1
                   fieldPath: spec.nodeName
             - name: OPENEBS_NAMESPACE
               valueFrom:
@@ -751,7 +752,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
             - name: OPENEBS_IO_HELPER_IMAGE
               value: "mayadataio/linux-utils:2.0.0-ee"
           # LEADER_ELECTION_ENABLED is used to enable/disable leader election. By default
@@ -4542,11 +4543,6 @@ kind: CSIDriver
 metadata:
   name: cstor.csi.openebs.io
 spec:
-  # Supports persistent inline volumes.
-  volumeLifecycleModes:
-    - Persistent
-    # Not yet supported but added just to support upgrade control plane seamlessly
-    - Ephemeral
   # To determine at runtime which mode a volume uses, pod info and its
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true

--- a/templates/openebs-operator-2.0.0.yaml
+++ b/templates/openebs-operator-2.0.0.yaml
@@ -200,7 +200,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
           # OPENEBS_IO_ANALYTICS_PING_INTERVAL can be used to specify the duration (in hours)
           # for periodic ping events sent to Google Analytics.
           # Default is 24h.
@@ -751,7 +751,7 @@ spec:
             - name: OPENEBS_IO_ENABLE_ANALYTICS
               value: "true"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "openebs-operator"
+              value: "openebs-enterprise-operator"
             - name: OPENEBS_IO_HELPER_IMAGE
               value: "openebs/linux-utils:2.0.0"
           # LEADER_ELECTION_ENABLED is used to enable/disable leader election. By default
@@ -4542,11 +4542,6 @@ kind: CSIDriver
 metadata:
   name: cstor.csi.openebs.io
 spec:
-  # Supports persistent inline volumes.
-  volumeLifecycleModes:
-    - Persistent
-    # Not yet supported but added just to support upgrade control plane seamlessly
-    - Ephemeral
   # To determine at runtime which mode a volume uses, pod info and its
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true

--- a/types/key.go
+++ b/types/key.go
@@ -37,6 +37,12 @@ const (
 	// AdmissionServerSVCNameKey is the name of admission server service
 	AdmissionServerSVCNameKey string = "admission-server-svc"
 
+	// APIServerContainerKey is the name of the container of maya-apiserver.
+	APIServerContainerKey string = "maya-apiserver"
+	// NodeDiskOperatorContainerKey is the name of the container of ndm-operator.
+	NodeDiskOperatorContainerKey string = "node-disk-operator"
+	// NodeDiskManagerContainerKey is the name of the container of ndm daemon.
+	NodeDiskManagerContainerKey string = "node-disk-manager"
 	// SnapshotControllerContainerKey is one of the container of snapshot operator
 	SnapshotControllerContainerKey string = "snapshot-controller"
 	// SnapshotProvisionerContainerKey is also one of the container of snapshot operator
@@ -319,6 +325,8 @@ const (
 	// CSISupportedVersionFromOpenEBS200 is the k8s version from where csi is supported for
 	// OpenEBS version 2.0.0 or greater.
 	CSISupportedVersionFromOpenEBS200 string = "v1.17.0"
+	// K8sVersion1170 is the const for kubernetes version v1.17.0
+	K8sVersion1170 string = "v1.17.0"
 
 	// OpenEBSMayaOperatorSANameKey is the name of OpenEBS service account.
 	OpenEBSMayaOperatorSANameKey string = "openebs-maya-operator"
@@ -423,37 +431,41 @@ const (
 	// if these are not installed via openebs-upgrade.
 	//
 	// NOTE: These keys and values can be used to identify a particular OpenEBS component.
-	ComponentNameLabelKey                      string = "openebs.io/component-name"
-	NDMComponentNameLabelValue                 string = "ndm"
-	NDMOperatorComponentNameLabelValue         string = "ndm-operator"
-	NDMConfigComponentNameLabelValue           string = "ndm-config"
-	CSPCOperatorComponentNameLabelValue        string = "cspc-operator"
-	CVCOperatorComponentNameLabelValue         string = "cvc-operator"
-	CVCOperatorServiceComponentNameLabelValue  string = "cvc-operator-svc"
-	MayaAPIServerComponentNameLabelValue       string = "maya-apiserver"
-	MayaAPIServerSVCComponentNameLabelValue    string = "maya-apiserver-svc"
-	AdmissionServerComponentNameLabelValue     string = "admission-webhook"
-	AdmissionServerSVCComponentNameLabelValue  string = "admission-webhook-svc"
-	LocalPVProvisionerComponentNameLabelValue  string = "openebs-localpv-provisioner"
-	OpenEBSProvisionerComponentNameLabelValue  string = "openebs-provisioner"
-	SnapshotOperatorComponentNameLabelValue    string = "openebs-snapshot-operator"
-	CStorCSINodeComponentNameLabelValue        string = "openebs-cstor-csi-node"
-	CStorCSIControllerComponentNameLabelValue  string = "openebs-cstor-csi-controller"
-	MayastorMOACComponentNameLabelValue        string = "moac"
-	MayastorMOACServiceComponentNameLabelValue string = "moac-svc"
-	MayastorMayastorComponentNameLabelValue    string = "mayastor"
+	ComponentNameLabelKey                            string = "openebs.io/component-name"
+	NDMComponentNameLabelValue                       string = "ndm"
+	NDMOperatorComponentNameLabelValue               string = "ndm-operator"
+	NDMConfigComponentNameLabelValue                 string = "ndm-config"
+	CSPCOperatorComponentNameLabelValue              string = "cspc-operator"
+	CVCOperatorComponentNameLabelValue               string = "cvc-operator"
+	CVCOperatorServiceComponentNameLabelValue        string = "cvc-operator-svc"
+	MayaAPIServerComponentNameLabelValue             string = "maya-apiserver"
+	MayaAPIServerSVCComponentNameLabelValue          string = "maya-apiserver-svc"
+	AdmissionServerComponentNameLabelValue           string = "admission-webhook"
+	AdmissionServerSVCComponentNameLabelValue        string = "admission-webhook-svc"
+	LocalPVProvisionerComponentNameLabelValue        string = "openebs-localpv-provisioner"
+	OpenEBSProvisionerComponentNameLabelValue        string = "openebs-provisioner"
+	SnapshotOperatorComponentNameLabelValue          string = "openebs-snapshot-operator"
+	CStorCSINodeComponentNameLabelValue              string = "openebs-cstor-csi-node"
+	CStorCSIControllerComponentNameLabelValue        string = "openebs-cstor-csi-controller"
+	CStorCSIISCSIADMConfigmapComponentNameLabelValue string = "openebs-cstor-csi-iscsiadm"
+	MayastorMOACComponentNameLabelValue              string = "moac"
+	MayastorMOACServiceComponentNameLabelValue       string = "moac-svc"
+	MayastorMayastorComponentNameLabelValue          string = "mayastor"
 
-	KeyName          string = "name"
-	KeyEnabled       string = "enabled"
-	KeyReplicas      string = "replicas"
-	KeyNodeSelector  string = "nodeSelector"
-	KeyAffinity      string = "affinity"
-	KeyTolerations   string = "tolerations"
-	KeyResources     string = "resources"
-	KeyImage         string = "image"
-	KeyImageTag      string = "imageTag"
-	KeyISCSIPath     string = "iscsiPath"
-	KeyAdoptionJobID string = "mayadata.io/openebsAdoptionJobId"
+	KeyName              string = "name"
+	KeyEnabled           string = "enabled"
+	KeyReplicas          string = "replicas"
+	KeyNodeSelector      string = "nodeSelector"
+	KeyAffinity          string = "affinity"
+	KeyTolerations       string = "tolerations"
+	KeyMatchLabels       string = "matchLabels"
+	KeyPodTemplateLabels string = "podTemplateLabels"
+	KeyResources         string = "resources"
+	KeyImage             string = "image"
+	KeyImageTag          string = "imageTag"
+	KeyContainerName     string = "containerName"
+	KeyISCSIPath         string = "iscsiPath"
+	KeyAdoptionJobID     string = "mayadata.io/openebsAdoptionJobId"
 
 	QUAYIOOPENEBSREGISTRY string = "quay.io/openebs/"
 	MAYADATAIOREGISTRY    string = "mayadataio/"

--- a/types/openebs.go
+++ b/types/openebs.go
@@ -139,13 +139,15 @@ type Analytics struct {
 // component such as it it is enabled or not, no of
 // replicas, nodeselector, etc.
 type Component struct {
-	Enabled      *bool                  `json:"enabled"`
-	Name         string                 `json:"name"`
-	Replicas     *int32                 `json:"replicas"`
-	Resources    map[string]interface{} `json:"resources"`
-	NodeSelector map[string]string      `json:"nodeSelector"`
-	Tolerations  []interface{}          `json:"tolerations"`
-	Affinity     map[string]interface{} `json:"affinity"`
+	Enabled           *bool                  `json:"enabled"`
+	Name              string                 `json:"name"`
+	Replicas          *int32                 `json:"replicas"`
+	Resources         map[string]interface{} `json:"resources"`
+	NodeSelector      map[string]string      `json:"nodeSelector"`
+	Tolerations       []interface{}          `json:"tolerations"`
+	Affinity          map[string]interface{} `json:"affinity"`
+	MatchLabels       map[string]string      `json:"matchLabels"`
+	PodTemplateLabels map[string]string      `json:"podTemplateLabels"`
 }
 
 // APIServer store the configuration for maya-apiserver
@@ -438,9 +440,11 @@ type MOACService struct {
 
 // Container stores the details of a container
 type Container struct {
-	ImageTag             string `json:"imageTag"`
-	Image                string `json:"image"`
-	EnableLeaderElection *bool  `json:"enableLeaderElection"`
+	ContainerName        string        `json:"containerName"`
+	ImageTag             string        `json:"imageTag"`
+	Image                string        `json:"image"`
+	EnableLeaderElection *bool         `json:"enableLeaderElection"`
+	ENV                  []interface{} `json:"env"`
 }
 
 // OpenEBSStatus defines the current status of


### PR DESCRIPTION
This PR fixes the following upgrade issue after adoption:
1. Immutability error due to selectors and matchLabels.
2. Immutability error while updating some envs such as OPENEBS_NAMESPACE.
3. Issue due to container name difference in helm and operator way of installation.

This PR also adds:
1. Update installer type from openebs-operator to openebs-enterprise-operator for google analytics.
2. Adds adoption logic for some of the new components such as openebs-iscsiadm configmap.
3. Adds logic to install CSIDriver based on K8s version.

It also does some refactoring wrt update logic of pod templates, label selector, etc.

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>