### PR TITLE
feat(install): install ISCSI client before OpenEBS installation

### DIFF
--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -11,6 +11,8 @@ spec:
   attachments:
     - apiVersion: dao.mayadata.io/v1alpha1
       resource: openebses
+      updateStrategy:
+        method: InPlace
     - apiVersion: apps/v1
       resource: daemonsets
       updateStrategy:

--- a/controller/adoptopenebs/common.go
+++ b/controller/adoptopenebs/common.go
@@ -69,6 +69,7 @@ func (p *Planner) formDefaultStoragePath() error {
 func (p *Planner) formCommonOpenEBSConfig() error {
 	var initFuncs = []func() error{
 		p.formDefaultStoragePath,
+		p.formPreInstallationConfig,
 		p.formJivaConfig,
 		p.formCStorConfig,
 		p.formAnalyticsConfig,

--- a/controller/adoptopenebs/preinstallationconfig.go
+++ b/controller/adoptopenebs/preinstallationconfig.go
@@ -1,0 +1,23 @@
+package adoptopenebs
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+// formPreInstallationConfig forms the desired OpenEBS CR config for components/tools/dependencies
+// which are required to be installed prior to OpenEBS installation.
+func (p *Planner) formPreInstallationConfig() error {
+	preInstallationConfig := &unstructured.Unstructured{
+		Object: make(map[string]interface{}, 0),
+	}
+	if p.PreInstallationConfig != nil {
+		preInstallationConfig = p.PreInstallationConfig
+	}
+	// form the config for ISCSI client installation, for adoption cases,
+	// it will be false by default since OpenEBS is already up and running.
+	iscsiClientConfig := make(map[string]interface{})
+	iscsiClientConfig["enabled"] = false
+	iscsiClientConfig["isSetupDone"] = true
+	preInstallationConfig.Object["iscsiClient"] = iscsiClientConfig
+	p.PreInstallationConfig = preInstallationConfig
+
+	return nil
+}

--- a/controller/adoptopenebs/preinstallationconfig.go
+++ b/controller/adoptopenebs/preinstallationconfig.go
@@ -14,8 +14,8 @@ func (p *Planner) formPreInstallationConfig() error {
 	// form the config for ISCSI client installation, for adoption cases,
 	// it will be false by default since OpenEBS is already up and running.
 	iscsiClientConfig := make(map[string]interface{})
-	iscsiClientConfig["enabled"] = false
-	iscsiClientConfig["isSetupDone"] = true
+	iscsiClientConfig["enabled"] = true
+	iscsiClientConfig["isSetupDone"] = false
 	preInstallationConfig.Object["iscsiClient"] = iscsiClientConfig
 	p.PreInstallationConfig = preInstallationConfig
 

--- a/controller/adoptopenebs/reconciler.go
+++ b/controller/adoptopenebs/reconciler.go
@@ -276,6 +276,7 @@ type Planner struct {
 	PoliciesConfig          *unstructured.Unstructured
 	AnalyticsConfig         *unstructured.Unstructured
 	MayastorConfig          *unstructured.Unstructured
+	PreInstallationConfig   *unstructured.Unstructured
 }
 
 // NewReconciler returns a new instance of Reconciler
@@ -466,6 +467,7 @@ func (p *Planner) getDesiredOpenEBS() error {
 		},
 		"spec": map[string]interface{}{
 			"version":                    p.OpenEBSVersion,
+			"preInstallation":            p.PreInstallationConfig,
 			"defaultStoragePath":         p.DefaultStoragePath,
 			"createDefaultStorageConfig": p.CreateDefaultStorageConfig,
 			"imagePrefix":                p.ImagePrefix,

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -622,6 +622,12 @@ func (p *Planner) getDesiredDaemonSet(daemon *unstructured.Unstructured) (*unstr
 		matchLabels = p.ObservedOpenEBS.Spec.MayastorConfig.MayastorCSI.MatchLabels
 		podTemplateLabels = p.ObservedOpenEBS.Spec.MayastorConfig.MayastorCSI.PodTemplateLabels
 		err = p.updateMayastorCSI(daemon)
+	case types.OpenEBSNodeSetupDaemonsetNameKey:
+		nodeSelector = p.ObservedOpenEBS.Spec.PreInstallation.ISCSIClient.NodeSelector
+		tolerations = p.ObservedOpenEBS.Spec.PreInstallation.ISCSIClient.Tolerations
+		affinity = p.ObservedOpenEBS.Spec.PreInstallation.ISCSIClient.Affinity
+		matchLabels = p.ObservedOpenEBS.Spec.PreInstallation.ISCSIClient.MatchLabels
+		podTemplateLabels = p.ObservedOpenEBS.Spec.PreInstallation.ISCSIClient.PodTemplateLabels
 	}
 	if err != nil {
 		return daemon, err

--- a/controller/openebs/iscsiclient.go
+++ b/controller/openebs/iscsiclient.go
@@ -1,0 +1,179 @@
+package openebs
+
+import (
+	"encoding/json"
+	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/openebs-upgrade/k8s"
+	"mayadata.io/openebs-upgrade/types"
+	"strings"
+)
+
+// getISCSISetupComponentsStatus checks if the components required to setup ISCSI client on nodes
+// are running or not, if they are in error, it will throw error. If they are already running which means
+// setup is already done, it will mark them for deletion.
+func (p *Planner) getISCSISetupComponentsStatus() (bool, error) {
+	var (
+		isRunning        bool
+		desiredDaemonset *unstructured.Unstructured
+		desiredConfigmap *unstructured.Unstructured
+	)
+	for _, component := range p.observedOpenEBSComponents {
+		if component.GetKind() == types.KindDaemonSet {
+			if component.GetName() == types.OpenEBSNodeSetupDaemonsetNameKey {
+				// get the .spec.status field and compare the currentNumberScheduled
+				// and desiredNumberScheduled field's values.
+				componentStatus, _, err := unstructured.NestedMap(component.Object, "status")
+				if err != nil {
+					return isRunning, err
+				}
+				if !(componentStatus == nil || len(componentStatus) == 0) {
+					desiredReplicas := componentStatus["desiredNumberScheduled"]
+					scheduledReplicas := componentStatus["currentNumberScheduled"]
+					readyReplicas := componentStatus["numberReady"]
+					// if desired replicas is equal to current replicas is equal to no of ready replicas
+					// then we can determine that ISCSI setup has completed or it was already installed
+					// and we will go ahead and clean up the daemonset.
+					if (desiredReplicas == scheduledReplicas) && (desiredReplicas == readyReplicas) {
+						desiredDaemonset = component
+					} else {
+						return isRunning, errors.Errorf("No of ready replicas: %d for daemonset[name: openebs-node-setup, namespace: %s] is not equal to no of desired replicas: %d",
+							readyReplicas, p.ObservedOpenEBS.Namespace, desiredReplicas)
+					}
+				}
+			}
+		} else if component.GetKind() == types.KindConfigMap {
+			if component.GetName() == types.OpenEBSNodeSetupConfigmapNameKey {
+				desiredConfigmap = component
+			}
+		}
+	}
+	// add daemonset and configmap to explicit deletes if and only if both are present.
+	if desiredDaemonset != nil {
+		// update the isSetupDone field in OpenEBS CR since it is a one time process
+		// and should not be done again once completed.
+		p.ObservedOpenEBS.Spec.PreInstallation.ISCSIClient.IsSetupDone = true
+		var openebs *unstructured.Unstructured
+		openebsRaw, err := json.Marshal(p.ObservedOpenEBS)
+		if err != nil {
+			return isRunning,
+				errors.Errorf("Error marshalling updated OpenEBS for updating ISCSI fields: %+v", err)
+		}
+		err = json.Unmarshal(openebsRaw, &openebs)
+		if err != nil {
+			return isRunning,
+				errors.Errorf("Error unmarshalling updated OpenEBS for updating ISCSI fields: %+v", err)
+		}
+		p.ExplicitUpdates = append(p.ExplicitUpdates, openebs)
+		p.ExplicitDeletes = append(p.ExplicitDeletes, desiredDaemonset)
+		if desiredConfigmap != nil {
+			p.ExplicitDeletes = append(p.ExplicitDeletes, desiredConfigmap)
+		}
+		isRunning = true
+	}
+	return isRunning, nil
+}
+
+// getDesiredISCSIManifests updates all the ISCSI component's manifest as per the provided
+// or the default values.
+func (p *Planner) getDesiredISCSIManifests(iscsiManifests map[string]*unstructured.Unstructured) (
+	map[string]*unstructured.Unstructured, error) {
+	var err error
+	for key, value := range iscsiManifests {
+		// set the common label i.e., openebs-upgrade.dao.mayadata.io/managed: true
+		// here since this label should be present in all the components irrespective
+		// of their k8s kind, however some specific labels could be set per component
+		// such as openebs-upgrade.dao.mayadata.io/component-name: ndm for NDM components,
+		// etc.
+		componentLabels := value.GetLabels()
+		if componentLabels == nil {
+			componentLabels = make(map[string]string, 0)
+		} else {
+			if _, exist := componentLabels[types.OpenEBSVersionLabelKey]; exist {
+				// update the version label as per the given OpenEBS version and imageTagSuffix
+				// if given.
+				componentLabels[types.OpenEBSVersionLabelKey] =
+					p.ObservedOpenEBS.Spec.Version + p.ObservedOpenEBS.Spec.ImageTagSuffix
+			}
+		}
+		componentLabels[types.OpenEBSUpgradeDAOManagedLabelKey] =
+			types.OpenEBSUpgradeDAOManagedLabelValue
+		value.SetLabels(componentLabels)
+
+		kind := strings.Split(key, "_")[1]
+		switch kind {
+		case types.KindDaemonSet:
+			value, err = p.getDesiredDaemonSet(value)
+		case types.KindConfigMap:
+			value, err = p.getDesiredConfigmap(value)
+		default:
+			// Doing nothing if an unknown kind
+			continue
+		}
+		if err != nil {
+			return iscsiManifests, errors.Errorf("Error updating ISCSI manifests: %+v", err)
+		}
+		// update manifest with the updated values
+		iscsiManifests[key] = value
+	}
+	return iscsiManifests, nil
+}
+
+// getISCSIInstallationManifest forms the YAML for ISCSI client installation on all the
+// desired nodes of a cluster.
+func (p *Planner) getISCSIInstallationManifest() (map[string]*unstructured.Unstructured, error) {
+	componentsYAMLMap := make(map[string]*unstructured.Unstructured)
+	var yamlFile string
+	// get the OS image running on the underlying node
+	osImage, err := k8s.GetOSImage()
+	if err != nil {
+		return componentsYAMLMap, errors.Errorf("Error getting OS image of a node, error: %+v", err)
+	}
+	osImageInLowercase := strings.ToLower(osImage)
+	switch true {
+	case strings.Contains(osImageInLowercase, "ubuntu"):
+		yamlFile = "/templates/iscsi-ubuntu-setup.yaml"
+	case strings.Contains(osImageInLowercase, strings.ToLower("Red Hat Enterprise Linux")) ||
+		strings.Contains(osImageInLowercase, "centos") ||
+		strings.Contains(osImageInLowercase, "amazon linux"):
+		yamlFile = "/templates/iscsi-amazonlinux-setup.yaml"
+	default:
+		glog.V(3).Infof("ISCSI installation is not yet supported for %s.", osImage)
+		return componentsYAMLMap, nil
+	}
+	iscsiYaml, err := ioutil.ReadFile(yamlFile)
+	if err != nil {
+		return componentsYAMLMap, errors.New("Error reading ISCSI installation YAML file.")
+	}
+
+	// form the mapping from component's "name_kind" as key to YAML
+	// string as value using ISCSI yaml.
+	componentsYAML := strings.Split(string(iscsiYaml), "---")
+	for _, componentYAML := range componentsYAML {
+		if componentYAML == "" {
+			continue
+		}
+		unstructuredYAML := unstructured.Unstructured{}
+		if err = yaml.Unmarshal([]byte(componentYAML), &unstructuredYAML.Object); err != nil {
+			return componentsYAMLMap, errors.Errorf("Error unmarshalling YAML string:%s, Error: %+v", componentYAML, err)
+		}
+		kind := unstructuredYAML.GetKind()
+		name := unstructuredYAML.GetName()
+
+		// Form the key using component's Name and kind separated
+		// by underscore
+		keyForStoringYaml := name + "_" + kind
+		// Store the latest yaml of each component in a map where the key
+		// is componentName_kind
+		componentsYAMLMap[keyForStoringYaml] = &unstructuredYAML
+	}
+	// get the desired ISCSI manifest with all the labels and values provided.
+	componentsYAMLMap, err = p.getDesiredISCSIManifests(componentsYAMLMap)
+	if err != nil {
+		return componentsYAMLMap, err
+	}
+	return componentsYAMLMap, nil
+}

--- a/controller/openebs/preinstallation.go
+++ b/controller/openebs/preinstallation.go
@@ -1,0 +1,56 @@
+package openebs
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// setPreInstallationDefaultsIfNotSet sets the default values for the dependencies
+// which are mandatory to be installed prior to OpenEBS installation such as ISCSI client
+// if not already given.
+func (p *Planner) setPreInstallationDefaultsIfNotSet() error {
+	if p.ObservedOpenEBS.Spec.PreInstallation.ISCSIClient.Enabled == nil {
+		p.ObservedOpenEBS.Spec.PreInstallation.ISCSIClient.Enabled = new(bool)
+		*p.ObservedOpenEBS.Spec.PreInstallation.ISCSIClient.Enabled = true
+	}
+	return nil
+}
+
+// getPreInstallationManifests returns a mapping of component's "name_kind" to YAML of
+// the components that are required to be installed prior to OpenEBS.
+// Note: This method makes use of the various preinstallation components YAMLs to form this
+// mapping such as ISCSI installation YAML.
+func (p *Planner) getPreInstallationManifests() error {
+	var err error
+	// initialize component manifests field.
+	if p.ComponentManifests == nil {
+		p.ComponentManifests = make(map[string]*unstructured.Unstructured, 0)
+	}
+	// set the pre-installation defaults.
+	err = p.setPreInstallationDefaultsIfNotSet()
+	if err != nil {
+		return err
+	}
+	if *p.ObservedOpenEBS.Spec.PreInstallation.ISCSIClient.Enabled &&
+		!p.ObservedOpenEBS.Spec.PreInstallation.ISCSIClient.IsSetupDone {
+		isISCSISetupComponentsRunning, err := p.getISCSISetupComponentsStatus()
+		if err != nil {
+			return err
+		}
+		if isISCSISetupComponentsRunning {
+			return nil
+		}
+		// get the ISCSI installation related YAMLs
+		iscsiYAMLMap, err := p.getISCSIInstallationManifest()
+		if err != nil {
+			return err
+		}
+		for key, value := range iscsiYAMLMap {
+			if key == "_" {
+				continue
+			}
+			p.ComponentManifests[key] = value
+		}
+	}
+
+	return nil
+}

--- a/templates/iscsi-amazonlinux-setup.yaml
+++ b/templates/iscsi-amazonlinux-setup.yaml
@@ -1,0 +1,118 @@
+apiVersion: v1
+data:
+  nodesetup.sh: |
+    #!/usr/bin/env bash
+
+    set -Euo pipefail functrace
+
+    ROOT_MOUNT_DIR="${ROOT_MOUNT_DIR:-/root}"
+
+    failure() {
+      local lineno=$1
+      local msg=$2
+      echo "Failed at $lineno: $msg"
+    }
+    trap 'failure ${LINENO} "$BASH_COMMAND"' ERR
+
+    echo "Checking if ISCSI client is installed or not..."
+    if [ -e /etc/iscsi/initiatorname.iscsi ]
+    then
+       echo "initiatorname.iscsi file is present."
+    else
+       echo "initiatorname.iscsi file is not present."
+    fi
+
+    if echo "$(chroot "${ROOT_MOUNT_DIR}" systemctl status iscsid)" | grep -q "running"
+    then
+       echo "ISCSI client is already running."
+       exit 0
+    else
+       echo "ISCSI client is not running."
+    fi
+
+    echo "Installing ISCSI client..."
+    chroot "${ROOT_MOUNT_DIR}" yum install iscsi-initiator-utils -y
+
+    echo "Enabling iscsid..."
+    chroot "${ROOT_MOUNT_DIR}" systemctl enable iscsid
+
+    echo "Starting iscsid..."
+    chroot "${ROOT_MOUNT_DIR}" systemctl start iscsid
+
+    echo "Verifying if ISCSI client is installed or not..."
+    if [ -e /etc/iscsi/initiatorname.iscsi ]
+    then
+       echo "initiatorname.iscsi file is present."
+    else
+       echo "initiatorname.iscsi file is not present."
+    fi
+
+    for i in {1..10}
+    do
+     if echo "$(chroot "${ROOT_MOUNT_DIR}" systemctl status iscsid)" | grep -q "running"
+     then
+       echo "ISCSI client has been installed successfully."
+       exit 0
+     else
+       echo "ISCSI client is not running."
+       if [ $i == 10 ]
+       then
+         exit 1
+       fi
+     fi
+    done
+kind: ConfigMap
+metadata:
+  name: node-setup
+  namespace: openebs
+
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: openebs-node-setup
+  namespace: openebs
+  labels:
+    openebs.io/component-name: openebs-node-setup
+spec:
+  selector:
+    matchLabels:
+      openebs.io/component-name: openebs-node-setup
+  template:
+    metadata:
+      labels:
+        openebs.io/component-name: openebs-node-setup
+    spec:
+      hostNetwork: true
+      hostPID: true
+      volumes:
+        - name: root-mount
+          hostPath:
+            path: /
+        - name: node-setup
+          configMap:
+            name: node-setup
+            defaultMode: 0744
+      initContainers:
+        - image: bash:5.0
+          name: init-node
+          command: ["/scripts/nodesetup.sh"]
+          env:
+            - name: ROOT_MOUNT_DIR
+              value: /root
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: root-mount
+              mountPath: /root
+            - name: node-setup
+              mountPath: /scripts
+      containers:
+        - name: wait
+          image: k8s.gcr.io/pause:3.1
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+  updateStrategy:
+    type: RollingUpdate

--- a/templates/iscsi-ubuntu-setup.yaml
+++ b/templates/iscsi-ubuntu-setup.yaml
@@ -1,0 +1,119 @@
+apiVersion: v1
+data:
+  nodesetup.sh: |
+    #!/usr/bin/env bash
+
+    set -Euo pipefail functrace
+
+    ROOT_MOUNT_DIR="${ROOT_MOUNT_DIR:-/root}"
+
+    failure() {
+      local lineno=$1
+      local msg=$2
+      echo "Failed at $lineno: $msg"
+    }
+    trap 'failure ${LINENO} "$BASH_COMMAND"' ERR
+
+    echo "Checking if ISCSI client is installed or not..."
+    if [ -e /etc/iscsi/initiatorname.iscsi ]
+    then
+       echo "initiatorname.iscsi file is present."
+    else
+       echo "initiatorname.iscsi file is not present."
+    fi
+
+    if echo "$(chroot "${ROOT_MOUNT_DIR}" systemctl status iscsid)" | grep -q "running"
+    then
+       echo "ISCSI client is already running."
+       exit 0
+    else
+       echo "ISCSI client is not running."
+    fi
+
+    echo "Installing ISCSI client..."
+    chroot "${ROOT_MOUNT_DIR}" apt-get update -qy
+    chroot "${ROOT_MOUNT_DIR}" apt-get install -qy open-iscsi xfsprogs
+
+    echo "Enabling iscsid..."
+    chroot "${ROOT_MOUNT_DIR}" systemctl enable iscsid
+
+    echo "Starting iscsid..."
+    chroot "${ROOT_MOUNT_DIR}" systemctl start iscsid
+
+    echo "Verifying if ISCSI client is installed or not..."
+    if [ -e /etc/iscsi/initiatorname.iscsi ]
+    then
+       echo "initiatorname.iscsi file is present."
+    else
+       echo "initiatorname.iscsi file is not present."
+    fi
+
+    for i in {1..10}
+    do
+     if echo "$(chroot "${ROOT_MOUNT_DIR}" systemctl status iscsid)" | grep -q "running"
+     then
+       echo "ISCSI client has been installed successfully."
+       exit 0
+     else
+       echo "ISCSI client is not running."
+       if [ $i == 10 ]
+       then
+         exit 1
+       fi
+     fi
+    done
+kind: ConfigMap
+metadata:
+  name: node-setup
+  namespace: openebs
+
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: openebs-node-setup
+  namespace: openebs
+  labels:
+    openebs.io/component-name: openebs-node-setup
+spec:
+  selector:
+    matchLabels:
+      openebs.io/component-name: openebs-node-setup
+  template:
+    metadata:
+      labels:
+        openebs.io/component-name: openebs-node-setup
+    spec:
+      hostNetwork: true
+      hostPID: true
+      volumes:
+        - name: root-mount
+          hostPath:
+            path: /
+        - name: node-setup
+          configMap:
+            name: node-setup
+            defaultMode: 0744
+      initContainers:
+        - image: bash:5.0
+          name: init-node
+          command: ["/scripts/nodesetup.sh"]
+          env:
+            - name: ROOT_MOUNT_DIR
+              value: /root
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: root-mount
+              mountPath: /root
+            - name: node-setup
+              mountPath: /scripts
+      containers:
+        - name: wait
+          image: k8s.gcr.io/pause:3.1
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+  updateStrategy:
+    type: RollingUpdate

--- a/types/key.go
+++ b/types/key.go
@@ -157,6 +157,13 @@ const (
 	// MayastorMOACSVCNameKey is the key to identify moac service
 	MayastorMOACSVCNameKey string = "moac-svc"
 
+	// OpenEBSNodeSetupDaemonsetNameKey is the name of daemonset which is launched to
+	// setup ISCSI client on nodes prior to OpenEBS installation.
+	OpenEBSNodeSetupDaemonsetNameKey string = "openebs-node-setup"
+	// OpenEBSNodeSetupConfigmapNameKey is the name of configmap which contains the
+	// configuration that is run to install ISCSI client on the nodes.
+	OpenEBSNodeSetupConfigmapNameKey string = "node-setup"
+
 	// KindClusterRole is the k8s kind of cluster role
 	KindClusterRole string = "ClusterRole"
 	// KindClusterRoleBinding is the k8s kind of cluster role binding

--- a/types/openebs.go
+++ b/types/openebs.go
@@ -78,10 +78,26 @@ type OpenEBSSpec struct {
 	//
 	// This can be overrided by providing it for a particular component in the
 	// component's specified section, for example, inside apiServer.
-	Resources map[string]interface{} `json:"resources"`
+	Resources map[string]interface{} `json:"resources,omitempty"`
 
 	// All the OpenEBS components that will get installed/updated.
 	Components `json:",inline"`
+
+	// PreInstallation specifies the components or the tools or the dependencies that needs
+	// to be installed prior to OpenEBS installation.
+	PreInstallation PreInstallation `json:"preInstallation,omitempty"`
+}
+
+// PreInstallation stores the components or the tools or the dependencies that needs
+// to be installed prior to OpenEBS installation.
+type PreInstallation struct {
+	ISCSIClient ISCSIClient `json:"iscsiClient"`
+}
+
+// ISCSIClient stores the configuration for ISCSI client installation.
+type ISCSIClient struct {
+	Component   `json:",inline"`
+	IsSetupDone bool `json:"isSetupDone"`
 }
 
 // Components stores all the OpenEBS components.
@@ -140,14 +156,14 @@ type Analytics struct {
 // replicas, nodeselector, etc.
 type Component struct {
 	Enabled           *bool                  `json:"enabled"`
-	Name              string                 `json:"name"`
-	Replicas          *int32                 `json:"replicas"`
-	Resources         map[string]interface{} `json:"resources"`
-	NodeSelector      map[string]string      `json:"nodeSelector"`
-	Tolerations       []interface{}          `json:"tolerations"`
-	Affinity          map[string]interface{} `json:"affinity"`
-	MatchLabels       map[string]string      `json:"matchLabels"`
-	PodTemplateLabels map[string]string      `json:"podTemplateLabels"`
+	Name              string                 `json:"name,omitempty"`
+	Replicas          *int32                 `json:"replicas,omitempty"`
+	Resources         map[string]interface{} `json:"resources,omitempty"`
+	NodeSelector      map[string]string      `json:"nodeSelector,omitempty"`
+	Tolerations       []interface{}          `json:"tolerations,omitempty"`
+	Affinity          map[string]interface{} `json:"affinity,omitempty"`
+	MatchLabels       map[string]string      `json:"matchLabels,omitempty"`
+	PodTemplateLabels map[string]string      `json:"podTemplateLabels,omitempty"`
 }
 
 // APIServer store the configuration for maya-apiserver
@@ -236,8 +252,8 @@ type NDMDaemon struct {
 	Sparse        *Sparse     `json:"sparse"`
 	Filters       *NDMFilters `json:"filters"`
 	Probes        *NDMProbes  `json:"probes"`
-	EnableHostPID *bool       `json:"enableHostPID"`
-	FeatureGates  []string    `json:"featureGates"`
+	EnableHostPID *bool       `json:"enableHostPID,omitempty"`
+	FeatureGates  []string    `json:"featureGates,omitempty"`
 }
 
 // NDMConfigMap stores the configuration for ndm configmap.
@@ -390,7 +406,7 @@ type CSINode struct {
 	Component `json:",inline"`
 	Container `json:",inline"`
 	// ISCSIPath is the path of the iscsiadm binary.
-	ISCSIPath string `json:"iscsiPath"`
+	ISCSIPath string `json:"iscsiPath,omitempty"`
 }
 
 // MayastorConfig stores the configuration for mayastor components.
@@ -440,11 +456,11 @@ type MOACService struct {
 
 // Container stores the details of a container
 type Container struct {
-	ContainerName        string        `json:"containerName"`
-	ImageTag             string        `json:"imageTag"`
-	Image                string        `json:"image"`
-	EnableLeaderElection *bool         `json:"enableLeaderElection"`
-	ENV                  []interface{} `json:"env"`
+	ContainerName        string        `json:"containerName,omitempty"`
+	ImageTag             string        `json:"imageTag,omitempty"`
+	Image                string        `json:"image,omitempty"`
+	EnableLeaderElection *bool         `json:"enableLeaderElection,omitempty"`
+	ENV                  []interface{} `json:"env,omitempty"`
 }
 
 // OpenEBSStatus defines the current status of


### PR DESCRIPTION
This PR adds functionality to install ISCSI client prior to OpenEBS
installation if not already installed.
Now, the controller will first launch a daemonset(along with a configmap) named `openebs-node-setup` which will run on all the
nodes of the cluster and will check if ISCSI client is already installed or not.
If not installed, it will install ISCSI clients on all the nodes and in the next
reconciliation, it will install the other OpenEBS components on the successful installation
of ISCSI client.

**Supported OS: Ubuntu, CentOS, RHEL, Amazon Linux.**

An example configuration which user can provide to configure this functionality(optional):
```
apiVersion: dao.mayadata.io/v1alpha1
kind: OpenEBS
metadata:
  name: install-openebs-1.9.0
  # Namespace i.e. the namespace where the openebs-upgrade operator and the
  # other openebs components will be installed/needs-to-be-installed.
  namespace: openebs
  labels:
    name: openebs-upgrade
spec:
  # OpenEBS Version to be installed.
  version: "1.9.0"
  # The components/tools/dependencies to be installed prior to OpenEBS components
  # installation.
  preInstallation:
    # iscsiClient contains configuration for ISCSI client installation.
    iscsiClient:
      # enabled: true means it should be installed.
      #
      # Defaults to true.
      enabled: true
      # This field denotes if the setup has already been done or not.
      # User can use this field to run client setup once again if required in case of
      # new node addition or so.
      #
      # Defaults to false.
      isSetupDone: true
```

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>