### PR TITLE
refactor(iscsi-install): do not delete existing components while installing ISCSI client

### DIFF
--- a/controller/openebs/preinstallation.go
+++ b/controller/openebs/preinstallation.go
@@ -2,6 +2,7 @@ package openebs
 
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/openebs-upgrade/types"
 )
 
 // setPreInstallationDefaultsIfNotSet sets the default values for the dependencies
@@ -49,6 +50,22 @@ func (p *Planner) getPreInstallationManifests() error {
 				continue
 			}
 			p.ComponentManifests[key] = value
+		}
+		// do not delete the existing components i.e., components which are already running in case of
+		// setting up ISCSI client.
+		// This will be the case where user wants to run ISCSI client setup when OpenEBS components
+		// are already running.
+		for _, component := range p.observedOpenEBSComponents {
+			if component.GetKind() == types.KindDaemonSet {
+				if component.GetName() == types.OpenEBSNodeSetupDaemonsetNameKey {
+					continue
+				}
+			} else if component.GetKind() == types.KindConfigMap {
+				if component.GetName() == types.OpenEBSNodeSetupConfigmapNameKey {
+					continue
+				}
+			}
+			p.ComponentManifests[component.GetName()+"_"+component.GetKind()] = component
 		}
 	}
 


### PR DESCRIPTION
This PR allows the existing components to be still running even during ISCSI client installation.
This is mainly useful in cases where ISCSI client setup is run when OpenEBS components are already running, in that case, it will delete any of the existing components and will only launch the components required for setting up ISCSI client.

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>