### PR TITLE
enhance(install): install ISCSI client alongwith OpenEBS components

### DIFF
--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -171,7 +171,17 @@ func (p *Planner) getManifests() error {
 		// is componentName_kind
 		componentsYAMLMap[keyForStoringYaml] = &unstructuredYAML
 	}
+	if !(p.ComponentManifests == nil || len(p.ComponentManifests) == 0) {
+		// add the already added manifests to this manifest
+		for manifestKey, manifestValue := range p.ComponentManifests {
+			if manifestKey == "_" {
+				continue
+			}
+			componentsYAMLMap[manifestKey] = manifestValue
+		}
+	}
 	p.ComponentManifests = componentsYAMLMap
+
 	return nil
 }
 

--- a/controller/openebs/preinstallation.go
+++ b/controller/openebs/preinstallation.go
@@ -2,7 +2,6 @@ package openebs
 
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"mayadata.io/openebs-upgrade/types"
 )
 
 // setPreInstallationDefaultsIfNotSet sets the default values for the dependencies
@@ -50,22 +49,6 @@ func (p *Planner) getPreInstallationManifests() error {
 				continue
 			}
 			p.ComponentManifests[key] = value
-		}
-		// do not delete the existing components i.e., components which are already running in case of
-		// setting up ISCSI client.
-		// This will be the case where user wants to run ISCSI client setup when OpenEBS components
-		// are already running.
-		for _, component := range p.observedOpenEBSComponents {
-			if component.GetKind() == types.KindDaemonSet {
-				if component.GetName() == types.OpenEBSNodeSetupDaemonsetNameKey {
-					continue
-				}
-			} else if component.GetKind() == types.KindConfigMap {
-				if component.GetName() == types.OpenEBSNodeSetupConfigmapNameKey {
-					continue
-				}
-			}
-			p.ComponentManifests[component.GetName()+"_"+component.GetKind()] = component
 		}
 	}
 

--- a/unstruct/util.go
+++ b/unstruct/util.go
@@ -371,6 +371,17 @@ func GetNestedSliceOrError(obj *unstructured.Unstructured, fields ...string) ([]
 	return slice, nil
 }
 
+// GetNestedSliceOrEmpty returns the slice found at given field path
+// of the given object. It returns empty slice in case of error or
+// if this slice was not found.
+func GetNestedSliceOrEmpty(obj *unstructured.Unstructured, fields ...string) ([]interface{}, error) {
+	nestedSlice, err := GetNestedSliceOrError(obj, fields...)
+	if nestedSlice == nil {
+		nestedSlice = make([]interface{}, 0)
+	}
+	return nestedSlice, err
+}
+
 // MergeToAnnotations merges the given key value pair against the
 // provided annotations
 func MergeToAnnotations(key, value string, given map[string]string) map[string]string {


### PR DESCRIPTION
This PR improves the ISCSI installation functionality where going forward,
all the OpenEBS components and the components to setup ISCSI client will be
installed at the same time.
Once installed, components created for setting up ISCSI client will be deleted.
It also adds initContainers to CSI node component which checks if ISCSI client is
installed or not,

**NOTE:** In case of the addition of a new node, users need to edit OpenEBS CR(`kubectl edit openebs -n openebs`) and change the value of `.spec.preInstallation.iscsiClient.isSetupDone` to `false` and `.spec.preInstallation.iscsiClient.Enabled` to `true` if not already set to `true`.

An example OpenEBS CR is given below:
```
apiVersion: dao.mayadata.io/v1alpha1
kind: OpenEBS
metadata:
  name: install-openebs-1.9.0
  # Namespace i.e. the namespace where the openebs-upgrade operator and the
  # other openebs components will be installed/needs-to-be-installed.
  namespace: openebs
  labels:
    name: openebs-upgrade
spec:
  # OpenEBS Version to be installed.
  version: "1.9.0"
  # The components/tools/dependencies to be installed prior to OpenEBS components
  # installation.
  preInstallation:
    # iscsiClient contains configuration for ISCSI client installation.
    iscsiClient:
      # enabled: true means it should be installed.
      #
      # Defaults to true.
      enabled: true
      # This field denotes if the setup has already been done or not.
      # User can use this field to run client setup once again if required in case of
      # new node addition or so.
      #
      # Defaults to false.
      isSetupDone: true
```

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>