### PR TITLE
fix(bug): enable GPTBasedUUID ndm feature flag by default

### DIFF
--- a/templates/openebs-operator-2.0.0-ee.yaml
+++ b/templates/openebs-operator-2.0.0-ee.yaml
@@ -487,8 +487,7 @@ spec:
           args:
             - -v=4
           # The feature-gate is used to enable the new UUID algorithm.
-          # This is a feature currently in Alpha state
-          #  - --feature-gates="GPTBasedUUID"
+            - --feature-gates="GPTBasedUUID"
           # The feature gate is used to start the gRPC API service. The gRPC server
           # starts at 9115 port by default. This feature is currently in Alpha state
           # - --feature-gates="APIService"

--- a/templates/openebs-operator-2.0.0.yaml
+++ b/templates/openebs-operator-2.0.0.yaml
@@ -486,8 +486,7 @@ spec:
           args:
             - -v=4
           # The feature-gate is used to enable the new UUID algorithm.
-          # This is a feature currently in Alpha state
-          #  - --feature-gates="GPTBasedUUID"
+            - --feature-gates="GPTBasedUUID"
           # The feature gate is used to start the gRPC API service. The gRPC server
           # starts at 9115 port by default. This feature is currently in Alpha state
           # - --feature-gates="APIService"


### PR DESCRIPTION
This PR enables GPTBasedUUID ndm feature flag by default for OpenEBS version
2.0.0 and 2.0.0-ee.

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>