### PR TITLE
enhance(install): update provisioner and admission-server containers

### DIFF
--- a/controller/adoptopenebs/admissionserver.go
+++ b/controller/adoptopenebs/admissionserver.go
@@ -5,6 +5,7 @@ import (
 	"mayadata.io/openebs-upgrade/types"
 	"mayadata.io/openebs-upgrade/unstruct"
 	"mayadata.io/openebs-upgrade/util"
+	"strings"
 )
 
 // formAdmissionServerConfig forms the desired OpenEBS CR config for admission-server.
@@ -31,7 +32,8 @@ func (p *Planner) formAdmissionServerConfig(admissionServer *unstructured.Unstru
 		if err != nil {
 			return err
 		}
-		if containerName == types.AdmissionServerContainerKey {
+		if containerName == types.AdmissionServerContainerKey ||
+			strings.Contains(containerName, types.AdmissionServerContainerKey) {
 			admissionServerDetails[types.KeyResources], _, err = unstructured.NestedMap(obj.Object,
 				"spec", "resources")
 			if err != nil {
@@ -48,6 +50,9 @@ func (p *Planner) formAdmissionServerConfig(admissionServer *unstructured.Unstru
 			}
 			if imageTag != p.OpenEBSVersion {
 				admissionServerDetails[types.KeyImageTag] = imageTag
+			}
+			if containerName != types.AdmissionServerContainerKey {
+				admissionServerDetails[types.KeyContainerName] = containerName
 			}
 		}
 		return nil

--- a/controller/adoptopenebs/provisioner.go
+++ b/controller/adoptopenebs/provisioner.go
@@ -5,6 +5,7 @@ import (
 	"mayadata.io/openebs-upgrade/types"
 	"mayadata.io/openebs-upgrade/unstruct"
 	"mayadata.io/openebs-upgrade/util"
+	"strings"
 )
 
 // formOpenEBSProvisionerConfig forms the desired OpenEBS CR config for openebs-provisioner.
@@ -28,7 +29,8 @@ func (p *Planner) formOpenEBSProvisionerConfig(provisioner *unstructured.Unstruc
 		if err != nil {
 			return err
 		}
-		if containerName == types.OpenEBSProvisionerContainerKey {
+		if containerName == types.OpenEBSProvisionerContainerKey ||
+			strings.Contains(containerName, "provisioner") {
 			provisionerDetails[types.KeyResources], _, err = unstructured.NestedMap(obj.Object,
 				"spec", "resources")
 			if err != nil {
@@ -53,6 +55,10 @@ func (p *Planner) formOpenEBSProvisionerConfig(provisioner *unstructured.Unstruc
 			p.ImagePrefix, err = util.GetImagePrefixFromContainerImage(image)
 			if err != nil {
 				return err
+			}
+
+			if containerName != types.OpenEBSProvisionerContainerKey {
+				provisionerDetails[types.KeyContainerName] = containerName
 			}
 		}
 		return nil

--- a/controller/openebs/admissionserver.go
+++ b/controller/openebs/admissionserver.go
@@ -86,6 +86,13 @@ func (p *Planner) updateAdmissionServer(deploy *unstructured.Unstructured) error
 			return err
 		}
 		if containerName == "admission-webhook" {
+			// update the container name if not same.
+			if len(p.ObservedOpenEBS.Spec.AdmissionServer.ContainerName) != 0 {
+				err = unstructured.SetNestedField(obj.Object, p.ObservedOpenEBS.Spec.AdmissionServer.ContainerName, "spec", "name")
+				if err != nil {
+					return err
+				}
+			}
 			// Set the image of the container.
 			err = unstructured.SetNestedField(obj.Object, p.ObservedOpenEBS.Spec.AdmissionServer.Image,
 				"spec", "image")

--- a/controller/openebs/provisioner.go
+++ b/controller/openebs/provisioner.go
@@ -85,6 +85,13 @@ func (p *Planner) updateOpenEBSProvisioner(deploy *unstructured.Unstructured) er
 			return err
 		}
 		if containerName == types.OpenEBSProvisionerContainerKey {
+			// update the container name if not same.
+			if len(p.ObservedOpenEBS.Spec.Provisioner.ContainerName) != 0 {
+				err = unstructured.SetNestedField(obj.Object, p.ObservedOpenEBS.Spec.Provisioner.ContainerName, "spec", "name")
+				if err != nil {
+					return err
+				}
+			}
 			// Set the image of the container.
 			err = unstructured.SetNestedField(obj.Object, p.ObservedOpenEBS.Spec.Provisioner.Image,
 				"spec", "image")


### PR DESCRIPTION
Issue: Container of openebs-provisioner is not getting updated properly in case the container name is different in case of adoption since the code is expecting it not to be other than openebs-provisioner. But in the case of installation through Kubera-charts(HELM), it is `kubera-charts-provisioner` instead of `openebs-provisioner`.

This PR updates the container details of openebs-provisioner and admission-server
even if the container name is different in case of installation through helm or so.

Issue: https://github.com/mayadata-io/oep/issues/330

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>