### PR TITLE
fix(CSI): add custom priority classes to run CSI components in openebs ns

### DIFF
--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -110,8 +110,11 @@ spec:
         - cstorvolumepolicies.cstor.openebs.io
         - cstorvolumereplicas.cstor.openebs.io
         - cstorbackups.openebs.io
+        - cstorbackups.cstor.openebs.io
         - cstorcompletedbackups.openebs.io
+        - cstorcompletedbackups.cstor.openebs.io
         - cstorrestores.openebs.io
+        - cstorrestores.cstor.openebs.io
         - mayastorpools.openebs.io
     - apiVersion: storage.k8s.io/v1beta1
       resource: csidrivers
@@ -125,6 +128,13 @@ spec:
         method: InPlace
       nameSelector:
         - mayastor
+    - apiVersion: scheduling.k8s.io/v1
+      resource: priorityclasses
+      updateStrategy:
+        method: InPlace
+      nameSelector:
+        - openebs-csi-controller-critical
+        - openebs-csi-node-critical
   hooks:
     sync:
       inline:

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -323,6 +323,8 @@ func (p *Planner) getDesiredManifests() error {
 			value, err = p.getDesiredCustomResourceDefinition(value)
 		case types.KindCSIDriver:
 			value, err = p.getDesiredCSIDriver(value)
+		case types.KindPriorityClass:
+			value, err = p.getDesiredPriorityClass(value)
 		default:
 			// Doing nothing if an unknown kind
 			continue

--- a/controller/openebs/priorityclass.go
+++ b/controller/openebs/priorityclass.go
@@ -1,0 +1,68 @@
+package openebs
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/openebs-upgrade/types"
+)
+
+// getDesiredPriorityClass updates the priorityClass manifest as per the given configuration.
+func (p *Planner) getDesiredPriorityClass(pc *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	var err error
+	switch pc.GetName() {
+	case types.OpenEBSCSIControllerPriorityClassNameKey:
+		err = p.updateCSIControllerPriorityClass(pc)
+	case types.OpenEBSCSINodePriorityClassNameKey:
+		err = p.updateCSINodePriorityClass(pc)
+	}
+	if err != nil {
+		return pc, err
+	}
+	// create annotations that refers to the instance which
+	// triggered creation of this PriorityClass.
+	pc.SetAnnotations(
+		map[string]string{
+			types.AnnKeyOpenEBSUID: string(p.ObservedOpenEBS.GetUID()),
+		},
+	)
+	return pc, nil
+}
+
+// updateCSINodePriorityClass updates the CSI node priority class manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateCSINodePriorityClass(crd *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := crd.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for CSI node
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-csi-node-critical
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.CSIComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.OpenEBSCSINodePriorityClassNameKey
+	// set the desired labels
+	crd.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateCSIControllerPriorityClass updates the CSI controller priority class manifest as per the
+// reconcile.ObservedOpenEBS values.
+func (p *Planner) updateCSIControllerPriorityClass(crd *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := crd.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Component specific labels for CSI controller
+	// 1. openebs-upgrade.dao.mayadata.io/component-group: csi
+	// 2. openebs-upgrade.dao.mayadata.io/component-name: openebs-csi-controller-critical
+	desiredLabels[types.OpenEBSComponentGroupLabelKey] =
+		types.CSIComponentGroupLabelValue
+	desiredLabels[types.OpenEBSComponentNameLabelKey] = types.OpenEBSCSIControllerPriorityClassNameKey
+	// set the desired labels
+	crd.SetLabels(desiredLabels)
+
+	return nil
+}

--- a/templates/openebs-operator-2.2.0-ee.yaml
+++ b/templates/openebs-operator-2.2.0-ee.yaml
@@ -4369,7 +4369,7 @@ spec:
         openebs.io/component-name: openebs-cstor-csi-controller
         openebs.io/version: 2.2.0-ee
     spec:
-      priorityClassName: system-cluster-critical
+      priorityClassName: openebs-csi-controller-critical
       serviceAccount: openebs-cstor-csi-controller-sa
       containers:
         - name: csi-resizer
@@ -4629,7 +4629,7 @@ spec:
         openebs.io/component-name: openebs-cstor-csi-node
         openebs.io/version: 2.2.0-ee
     spec:
-      priorityClassName: system-node-critical
+      priorityClassName: openebs-csi-node-critical
       serviceAccount: openebs-cstor-csi-node-sa
       hostNetwork: true
       containers:
@@ -4743,3 +4743,19 @@ spec:
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true
   attachRequired: true
+---
+apiVersion: scheduling.k8s.io/v1
+description: Used for system critical pods that must run in the cluster, but can be
+  moved to another node if necessary.
+kind: PriorityClass
+metadata:
+  name: openebs-csi-controller-critical
+value: 900000000
+---
+apiVersion: scheduling.k8s.io/v1
+description: Used for system critical pods that must not be moved from their current
+  node.
+kind: PriorityClass
+metadata:
+  name: openebs-csi-node-critical
+value: 900001000

--- a/templates/openebs-operator-2.2.0.yaml
+++ b/templates/openebs-operator-2.2.0.yaml
@@ -4369,7 +4369,7 @@ spec:
         openebs.io/component-name: openebs-cstor-csi-controller
         openebs.io/version: 2.2.0
     spec:
-      priorityClassName: system-cluster-critical
+      priorityClassName: openebs-csi-controller-critical
       serviceAccount: openebs-cstor-csi-controller-sa
       containers:
         - name: csi-resizer
@@ -4629,7 +4629,7 @@ spec:
         openebs.io/component-name: openebs-cstor-csi-node
         openebs.io/version: 2.2.0
     spec:
-      priorityClassName: system-node-critical
+      priorityClassName: openebs-csi-node-critical
       serviceAccount: openebs-cstor-csi-node-sa
       hostNetwork: true
       containers:
@@ -4743,3 +4743,19 @@ spec:
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true
   attachRequired: true
+---
+apiVersion: scheduling.k8s.io/v1
+description: Used for system critical pods that must run in the cluster, but can be
+  moved to another node if necessary.
+kind: PriorityClass
+metadata:
+  name: openebs-csi-controller-critical
+value: 900000000
+---
+apiVersion: scheduling.k8s.io/v1
+description: Used for system critical pods that must not be moved from their current
+  node.
+kind: PriorityClass
+metadata:
+  name: openebs-csi-node-critical
+value: 900001000

--- a/types/key.go
+++ b/types/key.go
@@ -186,7 +186,8 @@ const (
 	KindStatefulset string = "StatefulSet"
 	// KindCSIDriver is the k8s kind of csidriver.
 	KindCSIDriver string = "CSIDriver"
-
+	// KindPriorityClass is the k8s kind of PriorityClass.
+	KindPriorityClass string = "PriorityClass"
 	// MayaAPIServerManifestKey is used to get the manifest of maya-apiserver
 	MayaAPIServerManifestKey string = MayaAPIServerNameKey + "_" + KindDeployment
 	// MayaAPIServerServiceManifestKey is used to get the manifest of maya-apiserver-service
@@ -244,6 +245,10 @@ const (
 	CSPICRDV1NameKey = "cstorpoolinstances.cstor.openebs.io"
 	// CStorAdmissionServerNameKey is the name of CStor admission server
 	CStorAdmissionServerNameKey = "openebs-cstor-admission-server"
+	// OpenEBSCSINodePriorityClassNameKey is the name of OpenEBS CSI node priority class.
+	OpenEBSCSINodePriorityClassNameKey = "openebs-csi-node-critical"
+	// OpenEBSCSIControllerPriorityClassNameKey is the name of OpenEBS CSI controller priority class.
+	OpenEBSCSIControllerPriorityClassNameKey = "openebs-csi-controller-critical"
 
 	// CStorAdmissionServerManifestKey is used to get the manifest of CStor admission server
 	CStorAdmissionServerManifestKey string = CStorAdmissionServerNameKey + "_" + KindDeployment


### PR DESCRIPTION
This PR adds logic to add 2 new custom priority classes dedicated to CSI components:
csi-node and csi-controller.

The 2 new priority classes being introduced are:

1. For `csi-controller`:
```
apiVersion: scheduling.k8s.io/v1
description: Used for system critical pods that must run in the cluster, but can be
  moved to another node if necessary.
kind: PriorityClass
metadata:
  name: openebs-csi-controller-critical
value: 900000000
```
2. For csi-node
```
apiVersion: scheduling.k8s.io/v1
description: Used for system critical pods that must not be moved from their current
  node.
kind: PriorityClass
metadata:
  name: openebs-csi-node-critical
value: 900001000
```
Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>