### PR TITLE
enhance(install): add logic to update kubelet path

### DIFF
--- a/deploy/openebs.yaml
+++ b/deploy/openebs.yaml
@@ -13,6 +13,18 @@ spec:
   # OpenEBS Version to be installed.
   version: "1.9.0"
 
+  # k8sDistribution is the name of the kubernetes distribution being used.
+  #
+  # +optional
+  k8sDistribution: "microk8s"
+
+  # KubeletRootDirectory is the root directory for kubelet on each node.
+  # This variable should be used to override default kubelet root directory,
+  # it should contain only the kubelet root directory path.
+  #
+  # +optional
+  kubeletRootDirectory: "/var/lib/kubelet"
+
   # defaultStoragePath is the directory which will be used by
   # default for various OpenEBS operations i.e.,it can be used to
   # specify the hostpath to be used for default Jiva StoragePool

--- a/types/key.go
+++ b/types/key.go
@@ -486,6 +486,7 @@ const (
 	KeyContainerName     string = "containerName"
 	KeyISCSIPath         string = "iscsiPath"
 	KeyAdoptionJobID     string = "mayadata.io/openebsAdoptionJobId"
+	KeyMicroK8s          string = "microk8s"
 
 	QUAYIOOPENEBSREGISTRY string = "quay.io/openebs/"
 	MAYADATAIOREGISTRY    string = "mayadataio/"

--- a/types/openebs.go
+++ b/types/openebs.go
@@ -35,6 +35,17 @@ type OpenEBSSpec struct {
 	// OpenEBS Version to be installed or updated to.
 	Version string `json:"version"`
 
+	// K8sDistribution is the kubernetes distribution that is being used by the user
+	// such as microk8s, rancher, etc.
+	// This is an optional field and can be empty.
+	K8sDistribution string `json:"k8sDistribution"`
+
+	// KubeletRootDirectory is the root directory for kubelet on each node.
+	// This variable should be used to override default kubelet root directory.
+	//
+	// This is an optional field and can be empty.
+	KubeletRootDirectory string `json:"kubeletRootDirectory"`
+
 	// DefaultStoragePath is the directory which will be used by
 	// default for various OpenEBS operations i.e.,it can be used to
 	// specify the hostpath to be used for default Jiva StoragePool


### PR DESCRIPTION
- This PR adds logic to update kubelet path as well as configure `openebs-cstor-csi-node` as per the provided kubelet path.

- It adds `/var/snap/microk8s/common/var/lib/kubelet` as the default path for `microk8s`.

- It also exposes `k8sDistribution` variable to take the k8s distribution such as `microk8s` as input.
  **NOTE**: In case of OpenEBS Director, k8s distribution will be passed on from server.

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>