### PR TITLE
fix(bug): fix CRDs deletion and recreation in OpenEBS version<2.3.0

### DIFF
--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -223,6 +223,16 @@ spec:
         - openebs-maya-operator
         - openebs-cstor-csi-controller-sa
         - openebs-cstor-csi-node-sa
+    # The apiextensions.k8s.io/v1beta1 CRD list contains all the CRDs that are
+    # supported by OpenEBS different versions.
+    # A particular OpenEBS version can contain a subset of these CRDs also if not
+    # all of the listed below. Some of the CRDs may have been upgraded to apiextensions.k8s.io/v1
+    # but this list will still contain those CRDs if it was supported as apiextensions.k8s.io/v1beta1
+    # in any of the supported OpenEBS version.
+    #
+    # For instance, CRD cstorpoolclusters.cstor.openebs.io is supported as apiextensions.k8s.io/v1beta1
+    # in OpenEBS versions below 2.3.0 while it is supported as apiextensions.k8s.io/v1 in OpenEBS versions
+    # > 2.3.0 but it present in both the list i.e., apiextensions.k8s.io/v1beta1 and apiextensions.k8s.io/v1.
     - apiVersion: apiextensions.k8s.io/v1beta1
       resource: customresourcedefinitions
       updateStrategy:

--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -93,8 +93,6 @@ spec:
         - moac
     - apiVersion: apiextensions.k8s.io/v1beta1
       resource: customresourcedefinitions
-      updateStrategy:
-        method: InPlace
       nameSelector:
         - cstorpoolclusters.openebs.io
         - csinodeinfos.csi.storage.k8s.io
@@ -107,10 +105,18 @@ spec:
         - cstorcompletedbackups.openebs.io
         - cstorrestores.openebs.io
         - mayastorpools.openebs.io
+        - cstorpoolclusters.cstor.openebs.io
+        - cstorpoolinstances.cstor.openebs.io
+        - cstorvolumes.cstor.openebs.io
+        - cstorvolumeconfigs.cstor.openebs.io
+        - cstorvolumepolicies.cstor.openebs.io
+        - cstorvolumereplicas.cstor.openebs.io
+        - cstorbackups.cstor.openebs.io
+        - cstorcompletedbackups.cstor.openebs.io
+        - cstorrestores.cstor.openebs.io
+        - migrationtasks.openebs.io
     - apiVersion: apiextensions.k8s.io/v1
       resource: customresourcedefinitions
-      updateStrategy:
-        method: InPlace
       nameSelector:
         - cstorpoolclusters.cstor.openebs.io
         - cstorpoolinstances.cstor.openebs.io
@@ -215,8 +221,6 @@ spec:
         - openebs-cstor-csi-node-sa
     - apiVersion: apiextensions.k8s.io/v1beta1
       resource: customresourcedefinitions
-      updateStrategy:
-        method: InPlace
       nameSelector:
         - cstorpoolclusters.openebs.io
         - csinodeinfos.csi.storage.k8s.io
@@ -225,10 +229,18 @@ spec:
         - volumesnapshotcontents.snapshot.storage.k8s.io
         - volumesnapshots.snapshot.storage.k8s.io
         - cstorvolumeattachments.cstor.openebs.io
+        - cstorpoolclusters.cstor.openebs.io
+        - cstorpoolinstances.cstor.openebs.io
+        - cstorvolumes.cstor.openebs.io
+        - cstorvolumeconfigs.cstor.openebs.io
+        - cstorvolumepolicies.cstor.openebs.io
+        - cstorvolumereplicas.cstor.openebs.io
+        - cstorbackups.cstor.openebs.io
+        - cstorcompletedbackups.cstor.openebs.io
+        - cstorrestores.cstor.openebs.io
+        - migrationtasks.openebs.io
     - apiVersion: apiextensions.k8s.io/v1
       resource: customresourcedefinitions
-      updateStrategy:
-        method: InPlace
       nameSelector:
         - cstorpoolclusters.cstor.openebs.io
         - cstorpoolinstances.cstor.openebs.io

--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -93,6 +93,8 @@ spec:
         - moac
     - apiVersion: apiextensions.k8s.io/v1beta1
       resource: customresourcedefinitions
+      updateStrategy:
+        method: InPlace
       nameSelector:
         - cstorpoolclusters.openebs.io
         - csinodeinfos.csi.storage.k8s.io
@@ -117,6 +119,8 @@ spec:
         - migrationtasks.openebs.io
     - apiVersion: apiextensions.k8s.io/v1
       resource: customresourcedefinitions
+      updateStrategy:
+        method: InPlace
       nameSelector:
         - cstorpoolclusters.cstor.openebs.io
         - cstorpoolinstances.cstor.openebs.io
@@ -221,6 +225,8 @@ spec:
         - openebs-cstor-csi-node-sa
     - apiVersion: apiextensions.k8s.io/v1beta1
       resource: customresourcedefinitions
+      updateStrategy:
+        method: InPlace
       nameSelector:
         - cstorpoolclusters.openebs.io
         - csinodeinfos.csi.storage.k8s.io
@@ -241,6 +247,8 @@ spec:
         - migrationtasks.openebs.io
     - apiVersion: apiextensions.k8s.io/v1
       resource: customresourcedefinitions
+      updateStrategy:
+        method: InPlace
       nameSelector:
         - cstorpoolclusters.cstor.openebs.io
         - cstorpoolinstances.cstor.openebs.io

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -323,8 +323,6 @@ func (p *Planner) getDesiredManifests() error {
 		case types.KindCustomResourceDefinition:
 			value, err = p.getDesiredCustomResourceDefinition(value)
 			p.DesiredOpenEBSCRDs = append(p.DesiredOpenEBSCRDs, value)
-			// mark all CRDs for explicit updates.
-			p.ExplicitUpdates = append(p.ExplicitUpdates, value)
 		case types.KindCSIDriver:
 			value, err = p.getDesiredCSIDriver(value)
 		case types.KindPriorityClass:

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -279,7 +279,6 @@ func (p *Planner) removeDisabledManifests() error {
 // or the default values.
 func (p *Planner) getDesiredManifests() error {
 	var err error
-
 	for key, value := range p.ComponentManifests {
 		// set the common label i.e., openebs-upgrade.dao.mayadata.io/managed: true
 		// here since this label should be present in all the components irrespective
@@ -323,6 +322,9 @@ func (p *Planner) getDesiredManifests() error {
 			value, err = p.getDesiredStatefulSet(value)
 		case types.KindCustomResourceDefinition:
 			value, err = p.getDesiredCustomResourceDefinition(value)
+			p.DesiredOpenEBSCRDs = append(p.DesiredOpenEBSCRDs, value)
+			// mark all CRDs for explicit updates.
+			p.ExplicitUpdates = append(p.ExplicitUpdates, value)
 		case types.KindCSIDriver:
 			value, err = p.getDesiredCSIDriver(value)
 		case types.KindPriorityClass:
@@ -337,6 +339,7 @@ func (p *Planner) getDesiredManifests() error {
 		// update manifest with the updated values
 		p.ComponentManifests[key] = value
 	}
+
 	return nil
 }
 
@@ -898,7 +901,7 @@ func (p *Planner) updatePodTemplateVersionLabel(resource *unstructured.Unstructu
 // in order to update them such as .spec.selector, existing ENVs, spec.strategy, etc.
 func (p *Planner) getDesiredValuesFromObservedResources() error {
 	var err error
-	for _, observedOpenEBSComponent := range p.observedOpenEBSComponents {
+	for _, observedOpenEBSComponent := range p.ObservedOpenEBSComponents {
 		switch observedOpenEBSComponent.GetKind() {
 		case types.KindDeployment:
 			err = p.fillDesiredValuesFromObservedDeployments(observedOpenEBSComponent)

--- a/controller/openebs/cstor.go
+++ b/controller/openebs/cstor.go
@@ -570,7 +570,7 @@ func (p *Planner) deleteCSIComponentsIfRequired() error {
 	}
 	if isCSISupported && csiNamespace != types.NamespaceKubeSystem {
 		// check if csi-components are already installed in kube-system namespace.
-		for _, observedOpenEBSComp := range p.observedOpenEBSComponents {
+		for _, observedOpenEBSComp := range p.ObservedOpenEBSComponents {
 			if observedOpenEBSComp.GetKind() == types.KindStatefulset ||
 				observedOpenEBSComp.GetKind() == types.KindDaemonSet ||
 				observedOpenEBSComp.GetKind() == types.KindServiceAccount {

--- a/controller/openebs/iscsiclient.go
+++ b/controller/openebs/iscsiclient.go
@@ -21,7 +21,7 @@ func (p *Planner) getISCSISetupComponentsStatus() (bool, error) {
 		desiredDaemonset *unstructured.Unstructured
 		desiredConfigmap *unstructured.Unstructured
 	)
-	for _, component := range p.observedOpenEBSComponents {
+	for _, component := range p.ObservedOpenEBSComponents {
 		if component.GetKind() == types.KindDaemonSet {
 			if component.GetName() == types.OpenEBSNodeSetupDaemonsetNameKey {
 				// get the .spec.status field and compare the currentNumberScheduled


### PR DESCRIPTION
**Bug:**

After adding the support for OpenEBS 2.4.0 which included the upgrade of some of the cStor related CRDs from `apiVersion: apiextensions.k8s.io/v1beta1` to `apiVersion: apiextensions.k8s.io/v1` , the upgraded CRDs were getting deleted and recreated in case a user tries to install OpenEBS versions below 2.3.0 or is on OpenEBS versions below `2.3.0` which had all the CRDs in `apiVersion: apiextensions.k8s.io/v1beta1` only.
This works fine for OpenEBS version >= 2.3.0.

**Reason:**

The metac controller returns all the `apiVersion: apiextensions.k8s.io/v1beta1` CRDs also in the list of `apiVersion: apiextensions.k8s.io/v1` CRDs since when we apply an `apiVersion: apiextensions.k8s.io/v1beta1` CRD, the `apiVersion` for the CRD is present as `apiVersion: apiextensions.k8s.io/v1` only in the cluster as K8s stores all the CRDs in apiVersion: `apiextensions.k8s.io/v1` only even if the manifest has apiVersion: apiextensions.k8s.io/v1beta1.
Due to the above issue, there was a mismatch between the observed CRD resources and desired CRD resources due to different `apiVersions` being reported by metac for a single CRD resulting in 2 observed resources for a single CRD and only one desired resource being returned by code.
And the basic principle of metac is to delete the resource that is there in observed resources and not in desired resources and create the resource that is present in desired resources but not in observed resources.

**Solution:**

Since the deletion and recreation of CRDs are happening because of the absence of CRD resources in the desired resources list due to 2 different apiVersion being reported, we will now add those observed CRD resources to the desired list which are not present in the desired list so that metac does not think that it has to delete a CRD resource.

Signed-off-by: sagarkrsd <sagar.kumar@mayadata.io>