### PR TITLE
Update(intsall): support to install/upgrade OpenEBS 2.8.0 CE

### DIFF
--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -162,6 +162,12 @@ spec:
         method: InPlace
       nameSelector:
         - cstor.csi.openebs.io
+    - apiVersion: storage.k8s.io/v1
+        resource: csidrivers
+        updateStrategy:
+          method: InPlace
+        nameSelector:
+          - cstor.csi.openebs.io
     - apiVersion: v1
       resource: namespaces
       updateStrategy:

--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -163,11 +163,11 @@ spec:
       nameSelector:
         - cstor.csi.openebs.io
     - apiVersion: storage.k8s.io/v1
-        resource: csidrivers
-        updateStrategy:
-          method: InPlace
-        nameSelector:
-          - cstor.csi.openebs.io
+      resource: csidrivers
+      updateStrategy:
+        method: InPlace
+      nameSelector:
+        - cstor.csi.openebs.io
     - apiVersion: v1
       resource: namespaces
       updateStrategy:

--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -75,6 +75,7 @@ spec:
       updateStrategy:
         method: InPlace
       nameSelector:
+        - openebs-maya-operator
         - openebs-cstor-operator
         - openebs-cstor-migration
         - openebs-cstor-csi-snapshotter-binding
@@ -88,6 +89,7 @@ spec:
       updateStrategy:
         method: InPlace
       nameSelector:
+        - openebs-maya-operator
         - openebs-cstor-operator
         - openebs-cstor-migration
         - openebs-cstor-csi-snapshotter-role
@@ -102,6 +104,7 @@ spec:
         method: InPlace
       nameSelector:
         - openebs-maya-operator
+        - openebs-cstor-operator
         - openebs-cstor-csi-controller-sa
         - openebs-cstor-csi-node-sa
         - moac
@@ -136,6 +139,8 @@ spec:
       updateStrategy:
         method: InPlace
       nameSelector:
+        - blockdevices.openebs.io
+        - blockdeviceclaims.openebs.io
         - cstorpoolclusters.cstor.openebs.io
         - cstorpoolinstances.cstor.openebs.io
         - cstorvolumes.cstor.openebs.io
@@ -239,6 +244,7 @@ spec:
       updateStrategy:
         method: InPlace
       nameSelector:
+        - openebs-maya-operator
         - openebs-cstor-operator
         - openebs-cstor-migration
         - openebs-cstor-csi-snapshotter-binding
@@ -251,6 +257,7 @@ spec:
       updateStrategy:
         method: InPlace
       nameSelector:
+        - openebs-maya-operator
         - openebs-cstor-operator
         - openebs-cstor-migration
         - openebs-cstor-csi-snapshotter-role
@@ -264,6 +271,7 @@ spec:
         method: InPlace
       nameSelector:
         - openebs-maya-operator
+        - openebs-cstor-operator
         - openebs-cstor-csi-controller-sa
         - openebs-cstor-csi-node-sa
     # The apiextensions.k8s.io/v1beta1 CRD list contains all the CRDs that are
@@ -303,6 +311,8 @@ spec:
       updateStrategy:
         method: InPlace
       nameSelector:
+        - blockdevices.openebs.io
+        - blockdeviceclaims.openebs.io
         - cstorpoolclusters.cstor.openebs.io
         - cstorpoolinstances.cstor.openebs.io
         - cstorvolumes.cstor.openebs.io

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -347,20 +347,22 @@ func (p *Planner) getDesiredManifests() error {
 			p.DesiredOpenEBSCRDs = append(p.DesiredOpenEBSCRDs, value)
 		case types.KindCSIDriver:
 			if OpenEBSVersionAbove240 {
-				for _, observedCStorCSIDriver := range p.ObservedCStorCSIDriver {
-					if observedCStorCSIDriver != nil {
-						var isAttachRequired bool
-						// check the value of attachRequired, it will be true for OpenEBS
-						// versions below 2.5.0 which means it needs an upgrade which will
-						// be carried out by deletion and recreation of CSIDriver.
-						isAttachRequired, _, err = unstructured.NestedBool(observedCStorCSIDriver.Object,
-							"spec", "attachRequired")
-						if isAttachRequired {
-							// we will not add the latest CSI driver to the desired components list in
-							// this iteration so that the older CSI driver gets deleted.
-							p.ExplicitDeletes = append(p.ExplicitDeletes, observedCStorCSIDriver)
-							delete(p.ComponentManifests, key)
-							continue
+				if len(p.ObservedCStorCSIDriver) > 0 {
+					for _, observedCStorCSIDriver := range p.ObservedCStorCSIDriver {
+						if observedCStorCSIDriver != nil {
+							var isAttachRequired bool
+							// check the value of attachRequired, it will be true for OpenEBS
+							// versions below 2.5.0 which means it needs an upgrade which will
+							// be carried out by deletion and recreation of CSIDriver.
+							isAttachRequired, _, err = unstructured.NestedBool(observedCStorCSIDriver.Object,
+								"spec", "attachRequired")
+							if isAttachRequired {
+								// we will not add the latest CSI driver to the desired components list in
+								// this iteration so that the older CSI driver gets deleted.
+								p.ExplicitDeletes = append(p.ExplicitDeletes, observedCStorCSIDriver)
+								delete(p.ComponentManifests, key)
+								continue
+							}
 						}
 					}
 				}

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -347,19 +347,21 @@ func (p *Planner) getDesiredManifests() error {
 			p.DesiredOpenEBSCRDs = append(p.DesiredOpenEBSCRDs, value)
 		case types.KindCSIDriver:
 			if OpenEBSVersionAbove240 {
-				if p.ObservedCStorCSIDriver != nil {
-					var isAttachRequired bool
-					// check the value of attachRequired, it will be true for OpenEBS
-					// versions below 2.5.0 which means it needs an upgrade which will
-					// be carried out by deletion and recreation of CSIDriver.
-					isAttachRequired, _, err = unstructured.NestedBool(p.ObservedCStorCSIDriver.Object,
-						"spec", "attachRequired")
-					if isAttachRequired {
-						// we will not add the latest CSI driver to the desired components list in
-						// this iteration so that the older CSI driver gets deleted.
-						p.ExplicitDeletes = append(p.ExplicitDeletes, p.ObservedCStorCSIDriver)
-						delete(p.ComponentManifests, key)
-						continue
+				for _, observedCStorCSIDriver := range p.ObservedCStorCSIDriver {
+					if observedCStorCSIDriver != nil {
+						var isAttachRequired bool
+						// check the value of attachRequired, it will be true for OpenEBS
+						// versions below 2.5.0 which means it needs an upgrade which will
+						// be carried out by deletion and recreation of CSIDriver.
+						isAttachRequired, _, err = unstructured.NestedBool(observedCStorCSIDriver.Object,
+							"spec", "attachRequired")
+						if isAttachRequired {
+							// we will not add the latest CSI driver to the desired components list in
+							// this iteration so that the older CSI driver gets deleted.
+							p.ExplicitDeletes = append(p.ExplicitDeletes, observedCStorCSIDriver)
+							delete(p.ComponentManifests, key)
+							continue
+						}
 					}
 				}
 			}

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -349,20 +349,18 @@ func (p *Planner) getDesiredManifests() error {
 			if OpenEBSVersionAbove240 {
 				if len(p.ObservedCStorCSIDriver) > 0 {
 					for _, observedCStorCSIDriver := range p.ObservedCStorCSIDriver {
-						if observedCStorCSIDriver != nil {
-							var isAttachRequired bool
-							// check the value of attachRequired, it will be true for OpenEBS
-							// versions below 2.5.0 which means it needs an upgrade which will
-							// be carried out by deletion and recreation of CSIDriver.
-							isAttachRequired, _, err = unstructured.NestedBool(observedCStorCSIDriver.Object,
-								"spec", "attachRequired")
-							if isAttachRequired {
-								// we will not add the latest CSI driver to the desired components list in
-								// this iteration so that the older CSI driver gets deleted.
-								p.ExplicitDeletes = append(p.ExplicitDeletes, observedCStorCSIDriver)
-								delete(p.ComponentManifests, key)
-								continue
-							}
+						var isAttachRequired bool
+						// check the value of attachRequired, it will be true for OpenEBS
+						// versions below 2.5.0 which means it needs an upgrade which will
+						// be carried out by deletion and recreation of CSIDriver.
+						isAttachRequired, _, err = unstructured.NestedBool(observedCStorCSIDriver.Object,
+							"spec", "attachRequired")
+						if isAttachRequired {
+							// we will not add the latest CSI driver to the desired components list in
+							// this iteration so that the older CSI driver gets deleted.
+							p.ExplicitDeletes = append(p.ExplicitDeletes, observedCStorCSIDriver)
+							delete(p.ComponentManifests, key)
+							continue
 						}
 					}
 				}

--- a/controller/openebs/common.go
+++ b/controller/openebs/common.go
@@ -170,6 +170,8 @@ func (p *Planner) getManifests() error {
 		yamlFile = "/templates/openebs-operator-2.6.0.yaml"
 	case types.OpenEBSVersion270:
 		yamlFile = "/templates/openebs-operator-2.7.0.yaml"
+	case types.OpenEBSVersion280:
+		yamlFile = "/templates/openebs-operator-2.8.0.yaml"
 	default:
 		return errors.Errorf(
 			"Unsupported OpenEBS version provided, version: %+v", p.ObservedOpenEBS.Spec.Version)

--- a/controller/openebs/cstor.go
+++ b/controller/openebs/cstor.go
@@ -92,6 +92,7 @@ var SupportedCSIResizerVersionForOpenEBSVersion = map[string]string{
 	types.OpenEBSVersion250:    types.CSIResizerVersion110,
 	types.OpenEBSVersion260:    types.CSIResizerVersion110,
 	types.OpenEBSVersion270:    types.CSIResizerVersion110,
+	types.OpenEBSVersion280:    types.CSIResizerVersion110,
 }
 
 // SupportedCSISnapshotterVersionForOpenEBSVersion stores the mapping for
@@ -115,6 +116,7 @@ var SupportedCSISnapshotterVersionForOpenEBSVersion = map[string]string{
 	types.OpenEBSVersion250:    types.CSISnapshotterVersion303,
 	types.OpenEBSVersion260:    types.CSISnapshotterVersion303,
 	types.OpenEBSVersion270:    types.CSISnapshotterVersion303,
+	types.OpenEBSVersion280:    types.CSISnapshotterVersion303,
 }
 
 // SupportedCSISnapshotControllerVersionForOpenEBSVersion stores the mapping for
@@ -138,6 +140,7 @@ var SupportedCSISnapshotControllerVersionForOpenEBSVersion = map[string]string{
 	types.OpenEBSVersion250:    types.CSISnapshotControllerVersion303,
 	types.OpenEBSVersion260:    types.CSISnapshotControllerVersion303,
 	types.OpenEBSVersion270:    types.CSISnapshotControllerVersion303,
+	types.OpenEBSVersion280:    types.CSISnapshotControllerVersion303,
 }
 
 // SupportedCSIProvisionerVersionForCSIControllerVersion stores the mapping for
@@ -161,6 +164,7 @@ var SupportedCSIProvisionerVersionForCSIControllerVersion = map[string]string{
 	types.OpenEBSVersion250:    types.CSIProvisionerVersion210,
 	types.OpenEBSVersion260:    types.CSIProvisionerVersion210,
 	types.OpenEBSVersion270:    types.CSIProvisionerVersion210,
+	types.OpenEBSVersion280:    types.CSIProvisionerVersion210,
 }
 
 // SupportedCSIAttacherVersionForCSIControllerVersion stores the mapping for
@@ -184,6 +188,7 @@ var SupportedCSIAttacherVersionForCSIControllerVersion = map[string]string{
 	types.OpenEBSVersion250:    types.CSIAttacherVersion310,
 	types.OpenEBSVersion260:    types.CSIAttacherVersion310,
 	types.OpenEBSVersion270:    types.CSIAttacherVersion310,
+	types.OpenEBSVersion280:    types.CSIAttacherVersion310,
 }
 
 // SupportedCSIClusterDriverRegistrarVersionForOpenEBSVersion stores the mapping for
@@ -227,6 +232,7 @@ var SupportedCSINodeDriverRegistrarVersionForCSINodeVersion = map[string]string{
 	types.OpenEBSVersion250:    types.CSINodeDriverRegistrarVersion210,
 	types.OpenEBSVersion260:    types.CSINodeDriverRegistrarVersion210,
 	types.OpenEBSVersion270:    types.CSINodeDriverRegistrarVersion210,
+	types.OpenEBSVersion280:    types.CSINodeDriverRegistrarVersion210,
 }
 
 // Set the default values for Cstor if not already given.

--- a/controller/openebs/ndm.go
+++ b/controller/openebs/ndm.go
@@ -52,6 +52,7 @@ var SupportedNDMVersionForOpenEBSVersion = map[string]string{
 	types.OpenEBSVersion250:    types.NDMVersion110,
 	types.OpenEBSVersion260:    types.NDMVersion120,
 	types.OpenEBSVersion270:    types.NDMVersion130,
+	types.OpenEBSVersion280:    types.NDMVersion140,
 }
 
 // add/update NDM defaults if not already provided

--- a/controller/openebs/rbac.go
+++ b/controller/openebs/rbac.go
@@ -68,6 +68,8 @@ func (p *Planner) getDesiredServiceAccount(sa *unstructured.Unstructured) (*unst
 	case types.CStorCSINodeSANameKey:
 		sa.SetNamespace(csiNamespace)
 		err = p.updateCStorCSINodeServiceAccount(sa)
+	case types.OpenEBSCstorOperatorSANameKey:
+		err = p.updateOpenEBSCstorServiceAccount(sa)
 	case types.MoacSANameKey:
 		// Overwrite the namespace to mayastor for mayastor based components.
 		// Note: mayastor based components will be installed only in mayastor namespace only.
@@ -97,6 +99,29 @@ func (p *Planner) updateOpenEBSServiceAccount(sa *unstructured.Unstructured) err
 	// 1. openebs-upgrade.dao.mayadata.io/component-name: openebs-maya-operator
 	desiredLabels[types.OpenEBSComponentNameLabelKey] =
 		types.OpenEBSSAComponentNameLabelValue
+
+	// set the desired labels
+	sa.SetLabels(desiredLabels)
+
+	return nil
+}
+
+// updateOpenEBSCstorServiceAccount updates the openebs-cstor-operator service account
+// structure as per the provided values otherwise default values.
+func (p *Planner) updateOpenEBSCstorServiceAccount(sa *unstructured.Unstructured) error {
+	// desiredLabels is used to form the desired labels of a particular OpenEBS component.
+	desiredLabels := sa.GetLabels()
+	if desiredLabels == nil {
+		desiredLabels = make(map[string]string, 0)
+	}
+	// Set some component specific labels in order to identify specific components.
+	// These labels will be only set by openebs-upgrade and will help the end-users
+	// identify a particular or a set of OpenEBS components.
+	//
+	// Component specific labels for openebs-maya-operator service account:
+	// 1. openebs-upgrade.dao.mayadata.io/component-name: openebs-cstor-operator
+	desiredLabels[types.OpenEBSComponentNameLabelKey] =
+		types.OpenEBSCstorSAComponentNameLabelValue
 
 	// set the desired labels
 	sa.SetLabels(desiredLabels)

--- a/controller/openebs/reconciler.go
+++ b/controller/openebs/reconciler.go
@@ -367,6 +367,19 @@ func (p *Planner) getDesiredOpenEBSComponents() ReconcileResponse {
 		}
 	}
 
+	// add the observed Cstor CSI Driver to desired Cstor CSI Driver that is not already present in the desiredOpenEBS
+	// components list.
+	if p.ObservedCStorCSIDriver != nil {
+		key := p.ObservedCStorCSIDriver.GetName() + "_" + p.ObservedCStorCSIDriver.GetKind()
+		if desiredCstorCSIDriver, exist := p.ComponentManifests[key]; exist {
+			// If already exists then check if the APIVersion is same or not, if
+			// not then add it to the desired OpenEBS components list.
+			if desiredCstorCSIDriver.GetAPIVersion() != p.ObservedCStorCSIDriver.GetAPIVersion() {
+				response.DesiredOpenEBSComponents = append(response.DesiredOpenEBSComponents, p.ObservedCStorCSIDriver)
+			}
+		}
+	}
+
 	return response
 }
 

--- a/controller/openebs/reconciler.go
+++ b/controller/openebs/reconciler.go
@@ -115,7 +115,7 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 	// observedOpenEBSClusterRoleAndRoleBindings will store the details of all the OpenEBS
 	// related cluster role and cluster role bindings present in the cluster.
 	var observedOpenEBSClusterRoleAndRoleBindings []*unstructured.Unstructured
-	var observedCStorCSIDriver *unstructured.Unstructured
+	var observedCStorCSIDriver []*unstructured.Unstructured
 	for _, attachment := range request.Attachments.List() {
 		// this watch resource must be present in the list of attachments
 		if request.Watch.GetUID() == attachment.GetUID() &&
@@ -139,7 +139,7 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 		}
 		if attachment.GetKind() == types.KindCSIDriver &&
 			attachment.GetName() == types.CStorCSIDriverNameKey {
-			observedCStorCSIDriver = attachment
+			observedCStorCSIDriver = append(observedCStorCSIDriver, attachment)
 		}
 	}
 
@@ -221,7 +221,7 @@ type Reconciler struct {
 	ObservedOpenEBSComponents                 []*unstructured.Unstructured
 	ObservedOpenEBSCRDs                       []*unstructured.Unstructured
 	ObservedOpenEBSClusterRoleAndRoleBindings []*unstructured.Unstructured
-	ObservedCStorCSIDriver                    *unstructured.Unstructured
+	ObservedCStorCSIDriver                    []*unstructured.Unstructured
 }
 
 // ReconcilerConfig is a helper structure used to create a
@@ -231,7 +231,7 @@ type ReconcilerConfig struct {
 	ObservedOpenEBSComponents                 []*unstructured.Unstructured
 	ObservedOpenEBSCRDs                       []*unstructured.Unstructured
 	ObservedOpenEBSClusterRoleAndRoleBindings []*unstructured.Unstructured
-	ObservedCStorCSIDriver                    *unstructured.Unstructured
+	ObservedCStorCSIDriver                    []*unstructured.Unstructured
 }
 
 // ReconcileResponse is a helper struct used to form the response
@@ -250,7 +250,7 @@ type Planner struct {
 	ObservedOpenEBSComponents                 []*unstructured.Unstructured
 	ObservedOpenEBSCRDs                       []*unstructured.Unstructured
 	ObservedOpenEBSClusterRoleAndRoleBindings []*unstructured.Unstructured
-	ObservedCStorCSIDriver                    *unstructured.Unstructured
+	ObservedCStorCSIDriver                    []*unstructured.Unstructured
 
 	DesiredOpenEBSCRDs []*unstructured.Unstructured
 
@@ -369,13 +369,17 @@ func (p *Planner) getDesiredOpenEBSComponents() ReconcileResponse {
 
 	// add the observed Cstor CSI Driver to desired Cstor CSI Driver that is not already present in the desiredOpenEBS
 	// components list.
-	if p.ObservedCStorCSIDriver != nil {
-		key := p.ObservedCStorCSIDriver.GetName() + "_" + p.ObservedCStorCSIDriver.GetKind()
-		if desiredCstorCSIDriver, exist := p.ComponentManifests[key]; exist {
-			// If already exists then check if the APIVersion is same or not, if
-			// not then add it to the desired OpenEBS components list.
-			if desiredCstorCSIDriver.GetAPIVersion() != p.ObservedCStorCSIDriver.GetAPIVersion() {
-				response.DesiredOpenEBSComponents = append(response.DesiredOpenEBSComponents, p.ObservedCStorCSIDriver)
+	if len(p.ObservedCStorCSIDriver) > 0 {
+		for _, observedCStorCSIDriver := range p.ObservedCStorCSIDriver {
+			key := observedCStorCSIDriver.GetName() + "_" + observedCStorCSIDriver.GetKind()
+			glog.V(3).Infof("CSI DRIVER KEY: %s", key)
+			glog.V(3).Infof("CSI DRIVER API-VERSION: %s", observedCStorCSIDriver.GetAPIVersion())
+			if desiredCstorCSIDriver, exist := p.ComponentManifests[key]; exist {
+				// If already exists then check if the APIVersion is same or not, if
+				// not then add it to the desired OpenEBS components list.
+				if desiredCstorCSIDriver.GetAPIVersion() != observedCStorCSIDriver.GetAPIVersion() {
+					response.DesiredOpenEBSComponents = append(response.DesiredOpenEBSComponents, observedCStorCSIDriver)
+				}
 			}
 		}
 	}

--- a/templates/openebs-operator-2.8.0.yaml
+++ b/templates/openebs-operator-2.8.0.yaml
@@ -1,0 +1,6069 @@
+# Create Maya Service Account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-maya-operator
+  namespace: openebs
+---
+# Define Role that allows operations on K8s pods/deployments
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-maya-operator
+rules:
+  - apiGroups: ["*"]
+    resources: ["nodes", "nodes/proxy"]
+    verbs: ["*"]
+  - apiGroups: ["*"]
+    resources: ["namespaces", "services", "pods", "pods/exec", "deployments", "deployments/finalizers", "replicationcontrollers", "replicasets", "events", "endpoints", "configmaps", "secrets", "jobs", "cronjobs"]
+    verbs: ["*"]
+  - apiGroups: ["*"]
+    resources: ["statefulsets", "daemonsets"]
+    verbs: ["*"]
+  - apiGroups: ["*"]
+    resources: ["resourcequotas", "limitranges"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["*"]
+    resources: ["ingresses", "horizontalpodautoscalers", "verticalpodautoscalers", "certificatesigningrequests"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["*"]
+    resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]
+    verbs: ["*"]
+  - apiGroups: ["volumesnapshot.external-storage.k8s.io"]
+    resources: ["volumesnapshots", "volumesnapshotdatas"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: [ "get", "list", "create", "update", "delete", "patch"]
+  - apiGroups: ["openebs.io"]
+    resources: [ "*"]
+    verbs: ["*" ]
+  - apiGroups: ["cstor.openebs.io"]
+    resources: [ "*"]
+    verbs: ["*" ]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    verbs: ["get", "create", "list", "delete", "update", "patch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+  - apiGroups: ["*"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "create", "delete", "watch"]
+---
+# Bind the Service Account with the Role Privileges.
+# TODO: Check if default account also needs to be there
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-maya-operator
+subjects:
+  - kind: ServiceAccount
+    name: openebs-maya-operator
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-maya-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maya-apiserver
+  namespace: openebs
+  labels:
+    name: maya-apiserver
+    openebs.io/component-name: maya-apiserver
+    openebs.io/version: 2.8.0
+spec:
+  selector:
+    matchLabels:
+      name: maya-apiserver
+      openebs.io/component-name: maya-apiserver
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        name: maya-apiserver
+        openebs.io/component-name: maya-apiserver
+        openebs.io/version: 2.8.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: maya-apiserver
+          imagePullPolicy: IfNotPresent
+          image: openebs/m-apiserver:2.8.0
+          ports:
+            - containerPort: 5656
+          env:
+            # OPENEBS_IO_KUBE_CONFIG enables maya api service to connect to K8s
+            # based on this config. This is ignored if empty.
+            # This is supported for maya api server version 0.5.2 onwards
+            #- name: OPENEBS_IO_KUBE_CONFIG
+            #  value: "/home/ubuntu/.kube/config"
+            # OPENEBS_IO_K8S_MASTER enables maya api service to connect to K8s
+            # based on this address. This is ignored if empty.
+            # This is supported for maya api server version 0.5.2 onwards
+            #- name: OPENEBS_IO_K8S_MASTER
+            #  value: "http://172.28.128.3:8080"
+            # OPENEBS_NAMESPACE provides the namespace of this deployment as an
+            # environment variable
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # OPENEBS_SERVICE_ACCOUNT provides the service account of this pod as
+            # environment variable
+            - name: OPENEBS_SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            # OPENEBS_MAYA_POD_NAME provides the name of this pod as
+            # environment variable
+            - name: OPENEBS_MAYA_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # If OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG is false then OpenEBS default
+            # storageclass and storagepool will not be created.
+            - name: OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+              value: "true"
+            # OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL decides whether default cstor sparse pool should be
+            # configured as a part of openebs installation.
+            # If "true" a default cstor sparse pool will be configured, if "false" it will not be configured.
+            # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+            # is set to true
+            - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
+              value: "false"
+            # OPENEBS_IO_INSTALL_CRD environment variable is used to enable/disable CRD installation
+            # from Maya API server. By default the CRDs will be installed
+            # - name: OPENEBS_IO_INSTALL_CRD
+            #   value: "true"
+            # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+            # Where OpenEBS can store required files. Default base path will be /var/openebs
+            # - name: OPENEBS_IO_BASE_DIR
+            #   value: "/var/openebs"
+            # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
+            # to be used for saving the shared content between the side cars
+            # of cstor volume pod.
+            # The default path used is /var/openebs/sparse
+            #- name: OPENEBS_IO_CSTOR_TARGET_DIR
+            #  value: "/var/openebs/sparse"
+            # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath
+            # to be used for saving the shared content between the side cars
+            # of cstor pool pod. This ENV is also used to indicate the location
+            # of the sparse devices.
+            # The default path used is /var/openebs/sparse
+            #- name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+            #  value: "/var/openebs/sparse"
+            # OPENEBS_IO_JIVA_POOL_DIR can be used to specify the hostpath
+            # to be used for default Jiva StoragePool loaded by OpenEBS
+            # The default path used is /var/openebs
+            # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+            # is set to true
+            #- name: OPENEBS_IO_JIVA_POOL_DIR
+            #  value: "/var/openebs"
+            # OPENEBS_IO_LOCALPV_HOSTPATH_DIR can be used to specify the hostpath
+            # to be used for default openebs-hostpath storageclass loaded by OpenEBS
+            # The default path used is /var/openebs/local
+            # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+            # is set to true
+            #- name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
+            #  value: "/var/openebs/local"
+            - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
+              value: "openebs/jiva:2.8.0"
+            - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
+              value: "openebs/jiva:2.8.0"
+            - name: OPENEBS_IO_JIVA_REPLICA_COUNT
+              value: "3"
+            - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
+              value: "openebs/cstor-istgt:2.8.0"
+            - name: OPENEBS_IO_CSTOR_POOL_IMAGE
+              value: "openebs/cstor-pool:2.8.0"
+            - name: OPENEBS_IO_CSTOR_POOL_MGMT_IMAGE
+              value: "openebs/cstor-pool-mgmt:2.8.0"
+            - name: OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
+              value: "openebs/cstor-volume-mgmt:2.8.0"
+            - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
+              value: "openebs/m-exporter:2.8.0"
+            - name: OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
+              value: "openebs/m-exporter:2.8.0"
+            - name: OPENEBS_IO_HELPER_IMAGE
+              value: "openebs/linux-utils:2.8.0"
+            # OPENEBS_IO_ENABLE_ANALYTICS if set to true sends anonymous usage
+            # events to Google Analytics
+            - name: OPENEBS_IO_ENABLE_ANALYTICS
+              value: "true"
+            - name: OPENEBS_IO_INSTALLER_TYPE
+              value: "openebs-operator"
+          # OPENEBS_IO_ANALYTICS_PING_INTERVAL can be used to specify the duration (in hours)
+          # for periodic ping events sent to Google Analytics.
+          # Default is 24h.
+          # Minimum is 1h. You can convert this to weekly by setting 168h
+          #- name: OPENEBS_IO_ANALYTICS_PING_INTERVAL
+          #  value: "24h"
+          livenessProbe:
+            exec:
+              command:
+                - /usr/local/bin/mayactl
+                - version
+            initialDelaySeconds: 30
+            periodSeconds: 60
+          readinessProbe:
+            exec:
+              command:
+                - /usr/local/bin/mayactl
+                - version
+            initialDelaySeconds: 30
+            periodSeconds: 60
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: maya-apiserver-service
+  namespace: openebs
+  labels:
+    openebs.io/component-name: maya-apiserver-svc
+spec:
+  ports:
+    - name: api
+      port: 5656
+      protocol: TCP
+      targetPort: 5656
+  selector:
+    name: maya-apiserver
+  sessionAffinity: None
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-provisioner
+  namespace: openebs
+  labels:
+    name: openebs-provisioner
+    openebs.io/component-name: openebs-provisioner
+    openebs.io/version: 2.8.0
+spec:
+  selector:
+    matchLabels:
+      name: openebs-provisioner
+      openebs.io/component-name: openebs-provisioner
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        name: openebs-provisioner
+        openebs.io/component-name: openebs-provisioner
+        openebs.io/version: 2.8.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: openebs-provisioner
+          imagePullPolicy: IfNotPresent
+          image: openebs/openebs-k8s-provisioner:2.8.0
+          env:
+            # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
+            # based on this address. This is ignored if empty.
+            # This is supported for openebs provisioner version 0.5.2 onwards
+            #- name: OPENEBS_IO_K8S_MASTER
+            #  value: "http://10.128.0.12:8080"
+            # OPENEBS_IO_KUBE_CONFIG enables openebs provisioner to connect to K8s
+            # based on this config. This is ignored if empty.
+            # This is supported for openebs provisioner version 0.5.2 onwards
+            #- name: OPENEBS_IO_KUBE_CONFIG
+            #  value: "/home/ubuntu/.kube/config"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # OPENEBS_MAYA_SERVICE_NAME provides the maya-apiserver K8s service name,
+            # that provisioner should forward the volume create/delete requests.
+            # If not present, "maya-apiserver-service" will be used for lookup.
+            # This is supported for openebs provisioner version 0.5.3-RC1 onwards
+            #- name: OPENEBS_MAYA_SERVICE_NAME
+            #  value: "maya-apiserver-apiservice"
+            # LEADER_ELECTION_ENABLED is used to enable/disable leader election. By default
+            # leader election is enabled.
+            #- name: LEADER_ELECTION_ENABLED
+            #  value: "true"
+            # OPENEBS_IO_JIVA_PATCH_NODE_AFFINITY is used to enable/disable setting node affinity
+            # to the jiva replica deployments. Default is `enabled`. The valid values are
+            # `enabled` and `disabled`.
+            #- name: OPENEBS_IO_JIVA_PATCH_NODE_AFFINITY
+            #  value: "enabled"
+            # Process name used for matching is limited to the 15 characters
+            # present in the pgrep output.
+            # So fullname can't be used here with pgrep (>15 chars).A regular expression
+            # that matches the entire command name has to specified.
+            # Anchor `^` : matches any string that starts with `openebs-provis`
+            # `.*`: matches any string that has `openebs-provis` followed by zero or more char
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - test `pgrep -c "^openebs-provisi.*"` = 1
+            initialDelaySeconds: 30
+            periodSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-snapshot-operator
+  namespace: openebs
+  labels:
+    name: openebs-snapshot-operator
+    openebs.io/component-name: openebs-snapshot-operator
+    openebs.io/version: 2.8.0
+spec:
+  selector:
+    matchLabels:
+      name: openebs-snapshot-operator
+      openebs.io/component-name: openebs-snapshot-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: openebs-snapshot-operator
+        openebs.io/component-name: openebs-snapshot-operator
+        openebs.io/version: 2.8.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: snapshot-controller
+          image: openebs/snapshot-controller:2.8.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          # Process name used for matching is limited to the 15 characters
+          # present in the pgrep output.
+          # So fullname can't be used here with pgrep (>15 chars).A regular expression
+          # that matches the entire command name has to specified.
+          # Anchor `^` : matches any string that starts with `snapshot-contro`
+          # `.*`: matches any string that has `snapshot-contro` followed by zero or more char
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - test `pgrep -c "^snapshot-contro.*"` = 1
+            initialDelaySeconds: 30
+            periodSeconds: 60
+        # OPENEBS_MAYA_SERVICE_NAME provides the maya-apiserver K8s service name,
+        # that snapshot controller should forward the snapshot create/delete requests.
+        # If not present, "maya-apiserver-service" will be used for lookup.
+        # This is supported for openebs provisioner version 0.5.3-RC1 onwards
+        #- name: OPENEBS_MAYA_SERVICE_NAME
+        #  value: "maya-apiserver-apiservice"
+        - name: snapshot-provisioner
+          image: openebs/snapshot-provisioner:2.8.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          # OPENEBS_MAYA_SERVICE_NAME provides the maya-apiserver K8s service name,
+          # that snapshot provisioner  should forward the clone create/delete requests.
+          # If not present, "maya-apiserver-service" will be used for lookup.
+          # This is supported for openebs provisioner version 0.5.3-RC1 onwards
+          #- name: OPENEBS_MAYA_SERVICE_NAME
+          #  value: "maya-apiserver-apiservice"
+          # LEADER_ELECTION_ENABLED is used to enable/disable leader election. By default
+          # leader election is enabled.
+          #- name: LEADER_ELECTION_ENABLED
+          #  value: "true"
+          # Process name used for matching is limited to the 15 characters
+          # present in the pgrep output.
+          # So fullname can't be used here with pgrep (>15 chars).A regular expression
+          # that matches the entire command name has to specified.
+          # Anchor `^` : matches any string that starts with `snapshot-provis`
+          # `.*`: matches any string that has `snapshot-provis` followed by zero or more char
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - test `pgrep -c "^snapshot-provis.*"` = 1
+            initialDelaySeconds: 30
+            periodSeconds: 60
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: blockdevices.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: BlockDevice
+    listKind: BlockDeviceList
+    plural: blockdevices
+    shortNames:
+      - bd
+    singular: blockdevice
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.nodeAttributes.nodeName
+          name: NodeName
+          type: string
+        - jsonPath: .spec.path
+          name: Path
+          priority: 1
+          type: string
+        - jsonPath: .spec.filesystem.fsType
+          name: FSType
+          priority: 1
+          type: string
+        - jsonPath: .spec.capacity.storage
+          name: Size
+          type: string
+        - jsonPath: .status.claimState
+          name: ClaimState
+          type: string
+        - jsonPath: .status.state
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: BlockDevice is the Schema used to represent a BlockDevice CR
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DeviceSpec defines the properties and runtime status of a
+                BlockDevice
+              properties:
+                aggregateDevice:
+                  description: AggregateDevice was intended to store the hierachical
+                    information in cases of LVM. However this is currently not implemented
+                    and may need to be re-looked into for better design. To be deprecated
+                  type: string
+                capacity:
+                  description: Capacity
+                  properties:
+                    logicalSectorSize:
+                      description: LogicalSectorSize is blockdevice logical-sector size
+                        in bytes
+                      format: int32
+                      type: integer
+                    physicalSectorSize:
+                      description: PhysicalSectorSize is blockdevice physical-Sector
+                        size in bytes
+                      format: int32
+                      type: integer
+                    storage:
+                      description: Storage is the blockdevice capacity in bytes
+                      format: int64
+                      type: integer
+                  required:
+                    - storage
+                  type: object
+                claimRef:
+                  description: ClaimRef is the reference to the BDC which has claimed
+                    this BD
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                details:
+                  description: Details contain static attributes of BD like model,serial,
+                    and so forth
+                  properties:
+                    compliance:
+                      description: Compliance is standards/specifications version implemented
+                        by device firmware  such as SPC-1, SPC-2, etc
+                      type: string
+                    deviceType:
+                      description: DeviceType represents the type of device like sparse,
+                        disk, partition, lvm, crypt
+                      enum:
+                        - disk
+                        - partition
+                        - sparse
+                        - loop
+                        - lvm
+                        - crypt
+                        - dm
+                        - mpath
+                      type: string
+                    driveType:
+                      description: DriveType is the type of backing drive, HDD/SSD
+                      enum:
+                        - HDD
+                        - SSD
+                        - Unknown
+                        - ""
+                      type: string
+                    firmwareRevision:
+                      description: FirmwareRevision is the disk firmware revision
+                      type: string
+                    hardwareSectorSize:
+                      description: HardwareSectorSize is the hardware sector size in
+                        bytes
+                      format: int32
+                      type: integer
+                    logicalBlockSize:
+                      description: LogicalBlockSize is the logical block size in bytes
+                        reported by /sys/class/block/sda/queue/logical_block_size
+                      format: int32
+                      type: integer
+                    model:
+                      description: Model is model of disk
+                      type: string
+                    physicalBlockSize:
+                      description: PhysicalBlockSize is the physical block size in bytes
+                        reported by /sys/class/block/sda/queue/physical_block_size
+                      format: int32
+                      type: integer
+                    serial:
+                      description: Serial is serial number of disk
+                      type: string
+                    vendor:
+                      description: Vendor is vendor of disk
+                      type: string
+                  type: object
+                devlinks:
+                  description: DevLinks contains soft links of a block device like /dev/by-id/...
+                    /dev/by-uuid/...
+                  items:
+                    description: DeviceDevLink holds the mapping between type and links
+                      like by-id type or by-path type link
+                    properties:
+                      kind:
+                        description: Kind is the type of link like by-id or by-path.
+                        enum:
+                          - by-id
+                          - by-path
+                        type: string
+                      links:
+                        description: Links are the soft links
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                filesystem:
+                  description: FileSystem contains mountpoint and filesystem type
+                  properties:
+                    fsType:
+                      description: Type represents the FileSystem type of the block
+                        device
+                      type: string
+                    mountPoint:
+                      description: MountPoint represents the mountpoint of the block
+                        device.
+                      type: string
+                  type: object
+                nodeAttributes:
+                  description: NodeAttributes has the details of the node on which BD
+                    is attached
+                  properties:
+                    nodeName:
+                      description: NodeName is the name of the Kubernetes node resource
+                        on which the device is attached
+                      type: string
+                  type: object
+                parentDevice:
+                  description: "ParentDevice was intended to store the UUID of the parent
+                  Block Device as is the case for partitioned block devices. \n For
+                  example: /dev/sda is the parent for /dev/sda1 To be deprecated"
+                  type: string
+                partitioned:
+                  description: Partitioned represents if BlockDevice has partitions
+                    or not (Yes/No) Currently always default to No. To be deprecated
+                  enum:
+                    - "Yes"
+                    - "No"
+                  type: string
+                path:
+                  description: Path contain devpath (e.g. /dev/sdb)
+                  type: string
+              required:
+                - capacity
+                - devlinks
+                - nodeAttributes
+                - path
+              type: object
+            status:
+              description: DeviceStatus defines the observed state of BlockDevice
+              properties:
+                claimState:
+                  description: ClaimState represents the claim state of the block device
+                  enum:
+                    - Claimed
+                    - Unclaimed
+                    - Released
+                  type: string
+                state:
+                  description: State is the current state of the blockdevice (Active/Inactive/Unknown)
+                  enum:
+                    - Active
+                    - Inactive
+                    - Unknown
+                  type: string
+              required:
+                - claimState
+                - state
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: blockdeviceclaims.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: BlockDeviceClaim
+    listKind: BlockDeviceClaimList
+    plural: blockdeviceclaims
+    shortNames:
+      - bdc
+    singular: blockdeviceclaim
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.blockDeviceName
+          name: BlockDeviceName
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: BlockDeviceClaim is the Schema for the BlockDeviceClaim CR
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DeviceClaimSpec defines the request details for a BlockDevice
+              properties:
+                blockDeviceName:
+                  description: BlockDeviceName is the reference to the block-device
+                    backing this claim
+                  type: string
+                blockDeviceNodeAttributes:
+                  description: BlockDeviceNodeAttributes is the attributes on the node
+                    from which a BD should be selected for this claim. It can include
+                    nodename, failure domain etc.
+                  properties:
+                    hostName:
+                      description: HostName represents the hostname of the Kubernetes
+                        node resource where the BD should be present
+                      type: string
+                    nodeName:
+                      description: NodeName represents the name of the Kubernetes node
+                        resource where the BD should be present
+                      type: string
+                  type: object
+                deviceClaimDetails:
+                  description: Details of the device to be claimed
+                  properties:
+                    allowPartition:
+                      description: AllowPartition represents whether to claim a full
+                        block device or a device that is a partition
+                      type: boolean
+                    blockVolumeMode:
+                      description: 'BlockVolumeMode represents whether to claim a device
+                      in Block mode or Filesystem mode. These are use cases of BlockVolumeMode:
+                      1) Not specified: VolumeMode check will not be effective 2)
+                      VolumeModeBlock: BD should not have any filesystem or mountpoint
+                      3) VolumeModeFileSystem: BD should have a filesystem and mountpoint.
+                      If DeviceFormat is    specified then the format should match
+                      with the FSType in BD'
+                      type: string
+                    formatType:
+                      description: Format of the device required, eg:ext4, xfs
+                      type: string
+                  type: object
+                deviceType:
+                  description: DeviceType represents the type of drive like SSD, HDD
+                    etc.,
+                  nullable: true
+                  type: string
+                hostName:
+                  description: Node name from where blockdevice has to be claimed. To
+                    be deprecated. Use NodeAttributes.HostName instead
+                  type: string
+                resources:
+                  description: Resources will help with placing claims on Capacity,
+                    IOPS
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum resources required.
+                      eg: if storage resource of 10G is requested minimum capacity
+                      of 10G should be available TODO for validating'
+                      type: object
+                  required:
+                    - requests
+                  type: object
+                selector:
+                  description: Selector is used to find block devices to be considered
+                    for claiming
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the key
+                          and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to
+                              a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+              type: object
+            status:
+              description: DeviceClaimStatus defines the observed state of BlockDeviceClaim
+              properties:
+                phase:
+                  description: Phase represents the current phase of the claim
+                  type: string
+              required:
+                - phase
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+# This is the node-disk-manager related config.
+# It can be used to customize the disks probes and filters
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openebs-ndm-config
+  namespace: openebs
+  labels:
+    openebs.io/component-name: ndm-config
+data:
+  # udev-probe is default or primary probe which should be enabled to run ndm
+  # filterconfigs contails configs of filters - in their form fo include
+  # and exclude comma separated strings
+  node-disk-manager.config: |
+    probeconfigs:
+      - key: udev-probe
+        name: udev probe
+        state: true
+      - key: seachest-probe
+        name: seachest probe
+        state: false
+      - key: smart-probe
+        name: smart probe
+        state: true
+    filterconfigs:
+      - key: os-disk-exclude-filter
+        name: os disk exclude filter
+        state: true
+        exclude: "/,/etc/hosts,/boot"
+      - key: vendor-filter
+        name: vendor filter
+        state: true
+        include: ""
+        exclude: "CLOUDBYT,OpenEBS"
+      - key: path-filter
+        name: path filter
+        state: true
+        include: ""
+        exclude: "/dev/loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd,/dev/zd"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: openebs-ndm
+  namespace: openebs
+  labels:
+    name: openebs-ndm
+    openebs.io/component-name: ndm
+    openebs.io/version: 2.8.0
+spec:
+  selector:
+    matchLabels:
+      name: openebs-ndm
+      openebs.io/component-name: ndm
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: openebs-ndm
+        openebs.io/component-name: ndm
+        openebs.io/version: 2.8.0
+    spec:
+      # By default the node-disk-manager will be run on all kubernetes nodes
+      # If you would like to limit this to only some nodes, say the nodes
+      # that have storage attached, you could label those node and use
+      # nodeSelector.
+      #
+      # e.g. label the storage nodes with - "openebs.io/nodegroup"="storage-node"
+      # kubectl label node <node-name> "openebs.io/nodegroup"="storage-node"
+      #nodeSelector:
+      #  "openebs.io/nodegroup": "storage-node"
+      serviceAccountName: openebs-maya-operator
+      hostNetwork: true
+      # host PID is used to check status of iSCSI Service when the NDM
+      # API service is enabled
+      #hostPID: true
+      containers:
+        - name: node-disk-manager
+          image: openebs/node-disk-manager:1.4.0
+          args:
+            - -v=4
+            # The feature-gate is used to enable the new UUID algorithm.
+            - --feature-gates="GPTBasedUUID"
+          # The feature gate is used to start the gRPC API service. The gRPC server
+          # starts at 9115 port by default. This feature is currently in Alpha state
+          # - --feature-gates="APIService"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: config
+              mountPath: /host/node-disk-manager.config
+              subPath: node-disk-manager.config
+              readOnly: true
+            - name: udev
+              mountPath: /run/udev
+            - name: procmount
+              mountPath: /host/proc
+              readOnly: true
+            - name: devmount
+              mountPath: /dev
+            - name: basepath
+              mountPath: /var/openebs/ndm
+            - name: sparsepath
+              mountPath: /var/openebs/sparse
+          env:
+            # namespace in which NDM is installed will be passed to NDM Daemonset
+            # as environment variable
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # pass hostname as env variable using downward API to the NDM container
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # specify the directory where the sparse files need to be created.
+            # if not specified, then sparse files will not be created.
+            - name: SPARSE_FILE_DIR
+              value: "/var/openebs/sparse"
+            # Size(bytes) of the sparse file to be created.
+            - name: SPARSE_FILE_SIZE
+              value: "10737418240"
+            # Specify the number of sparse files to be created
+            - name: SPARSE_FILE_COUNT
+              value: "0"
+          livenessProbe:
+            exec:
+              command:
+                - pgrep
+                - "ndm"
+            initialDelaySeconds: 30
+            periodSeconds: 60
+      volumes:
+        - name: config
+          configMap:
+            name: openebs-ndm-config
+        - name: udev
+          hostPath:
+            path: /run/udev
+            type: Directory
+        # mount /proc (to access mount file of process 1 of host) inside container
+        # to read mount-point of disks and partitions
+        - name: procmount
+          hostPath:
+            path: /proc
+            type: Directory
+        - name: devmount
+          # the /dev directory is mounted so that we have access to the devices that
+          # are connected at runtime of the pod.
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: basepath
+          hostPath:
+            path: /var/openebs/ndm
+            type: DirectoryOrCreate
+        - name: sparsepath
+          hostPath:
+            path: /var/openebs/sparse
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-ndm-operator
+  namespace: openebs
+  labels:
+    name: openebs-ndm-operator
+    openebs.io/component-name: ndm-operator
+    openebs.io/version: 2.8.0
+spec:
+  selector:
+    matchLabels:
+      name: openebs-ndm-operator
+      openebs.io/component-name: ndm-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: openebs-ndm-operator
+        openebs.io/component-name: ndm-operator
+        openebs.io/version: 2.8.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: node-disk-operator
+          image: openebs/node-disk-operator:1.4.0
+          imagePullPolicy: IfNotPresent
+          readinessProbe:
+            exec:
+              command:
+                - stat
+                - /tmp/operator-sdk-ready
+            initialDelaySeconds: 4
+            periodSeconds: 10
+            failureThreshold: 1
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # the service account of the ndm-operator pod
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: OPERATOR_NAME
+              value: "node-disk-operator"
+            - name: CLEANUP_JOB_IMAGE
+              value: "openebs/linux-utils:2.8.0"
+            # OPENEBS_IO_INSTALL_CRD environment variable is used to enable/disable CRD installation
+            # from NDM operator. By default the CRDs will be installed
+            - name: OPENEBS_IO_INSTALL_CRD
+              value: "false"
+            # OPENEBS_IO_IMAGE_PULL_SECRETS environment variable is used to pass the image pull secrets
+            # to the cleanup pod launched by NDM operator
+            #- name: OPENEBS_IO_IMAGE_PULL_SECRETS
+            #  value: ""
+          # Process name used for matching is limited to the 15 characters
+          # present in the pgrep output.
+          # So fullname can be used here with pgrep (cmd is < 15 chars).
+          livenessProbe:
+            exec:
+              command:
+                - pgrep
+                - "ndo"
+            initialDelaySeconds: 30
+            periodSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-admission-server
+  namespace: openebs
+  labels:
+    app: admission-webhook
+    openebs.io/component-name: admission-webhook
+    openebs.io/version: 2.8.0
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  selector:
+    matchLabels:
+      app: admission-webhook
+  template:
+    metadata:
+      labels:
+        app: admission-webhook
+        openebs.io/component-name: admission-webhook
+        openebs.io/version: 2.8.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: admission-webhook
+          image: openebs/admission-server:2.8.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - -alsologtostderr
+            - -v=2
+            - 2>&1
+          env:
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ADMISSION_WEBHOOK_NAME
+              value: "openebs-admission-server"
+            - name: ADMISSION_WEBHOOK_FAILURE_POLICY
+              value: "Fail"
+          # Process name used for matching is limited to the 15 characters
+          # present in the pgrep output.
+          # So fullname can't be used here with pgrep (>15 chars).A regular expression
+          # Anchor `^` : matches any string that starts with `admission-serve`
+          # `.*`: matche any string that has `admission-serve` followed by zero or more char
+          # that matches the entire command name has to specified.
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - test `pgrep -c "^admission-serve.*"` = 1
+            initialDelaySeconds: 30
+            periodSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-localpv-provisioner
+  namespace: openebs
+  labels:
+    name: openebs-localpv-provisioner
+    openebs.io/component-name: openebs-localpv-provisioner
+    openebs.io/version: 2.8.0
+spec:
+  selector:
+    matchLabels:
+      name: openebs-localpv-provisioner
+      openebs.io/component-name: openebs-localpv-provisioner
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: openebs-localpv-provisioner
+        openebs.io/component-name: openebs-localpv-provisioner
+        openebs.io/version: 2.8.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: openebs-provisioner-hostpath
+          imagePullPolicy: IfNotPresent
+          image: openebs/provisioner-localpv:2.8.0
+          env:
+            # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
+            # based on this address. This is ignored if empty.
+            # This is supported for openebs provisioner version 0.5.2 onwards
+            #- name: OPENEBS_IO_K8S_MASTER
+            #  value: "http://10.128.0.12:8080"
+            # OPENEBS_IO_KUBE_CONFIG enables openebs provisioner to connect to K8s
+            # based on this config. This is ignored if empty.
+            # This is supported for openebs provisioner version 0.5.2 onwards
+            #- name: OPENEBS_IO_KUBE_CONFIG
+            #  value: "/home/ubuntu/.kube/config"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # OPENEBS_SERVICE_ACCOUNT provides the service account of this pod as
+            # environment variable
+            - name: OPENEBS_SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: OPENEBS_IO_ENABLE_ANALYTICS
+              value: "true"
+            - name: OPENEBS_IO_INSTALLER_TYPE
+              value: "openebs-operator"
+            - name: OPENEBS_IO_HELPER_IMAGE
+              value: "openebs/linux-utils:2.8.0"
+          # LEADER_ELECTION_ENABLED is used to enable/disable leader election. By default
+          # leader election is enabled.
+          #- name: LEADER_ELECTION_ENABLED
+          #  value: "true"
+          # OPENEBS_IO_IMAGE_PULL_SECRETS environment variable is used to pass the image pull secrets
+          # to the helper pod launched by local-pv hostpath provisioner
+          #- name: OPENEBS_IO_IMAGE_PULL_SECRETS
+          #  value: ""
+          # Process name used for matching is limited to the 15 characters
+          # present in the pgrep output.
+          # So fullname can't be used here with pgrep (>15 chars).A regular expression
+          # that matches the entire command name has to specified.
+          # Anchor `^` : matches any string that starts with `provisioner-loc`
+          # `.*`: matches any string that has `provisioner-loc` followed by zero or more char
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - test `pgrep -c "^provisioner-loc.*"` = 1
+            initialDelaySeconds: 30
+            periodSeconds: 60
+---
+# Create Maya Service Account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-cstor-operator
+  namespace: openebs
+---
+# Define Role that allows operations on K8s pods/deployments
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-operator
+rules:
+  - apiGroups: ["*"]
+    resources: ["nodes", "nodes/proxy"]
+    verbs: ["*"]
+  - apiGroups: ["*"]
+    resources: ["namespaces", "services", "pods", "deployments", "deployments/finalizers", "replicationcontrollers", "replicasets", "events", "endpoints", "configmaps", "secrets", "jobs", "cronjobs"]
+    verbs: ["*"]
+  - apiGroups: ["*"]
+    resources: ["statefulsets", "daemonsets"]
+    verbs: ["*"]
+  - apiGroups: ["*"]
+    resources: ["resourcequotas", "limitranges"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["*"]
+    resources: ["certificatesigningrequests"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["*"]
+    resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]
+    verbs: ["*"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: [ "get", "list", "create", "update", "delete", "patch"]
+  - apiGroups: ["openebs.io"]
+    resources: ["*"]
+    verbs: ["*" ]
+  - apiGroups: ["cstor.openebs.io"]
+    resources: ["*"]
+    verbs: ["*" ]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    verbs: ["get", "create", "list", "delete", "update", "patch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+  - apiGroups: ["*"]
+    resources: ["upgradetasks", "migrationtasks"]
+    verbs: ["*"]
+  - apiGroups: ["*"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "create", "delete", "watch"]
+---
+# Bind the Service Account with the Role Privileges.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-operator
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-operator
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Define Role that allows operations required for migration of snapshots
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-migration
+rules:
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create", "get", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-migration
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-operator
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-migration
+  apiGroup: rbac.authorization.k8s.io
+---
+###########################################################################
+####                                                                   ####
+####                     CStor-Operator yaml                           ####
+####                                                                   ####
+###########################################################################
+#
+#
+###########################################################################
+#                                                                       ###
+#                        CStorPoolCluster CRD                           ###
+#                                                                       ###
+###########################################################################
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: cstorpoolclusters.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorPoolCluster
+    listKind: CStorPoolClusterList
+    plural: cstorpoolclusters
+    shortNames:
+      - cspc
+    singular: cstorpoolcluster
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The number of healthy cStorPoolInstances
+          jsonPath: .status.healthyInstances
+          name: HealthyInstances
+          type: integer
+        - description: The number of provisioned cStorPoolInstances
+          jsonPath: .status.provisionedInstances
+          name: ProvisionedInstances
+          type: integer
+        - description: The number of desired cStorPoolInstances
+          jsonPath: .status.desiredInstances
+          name: DesiredInstances
+          type: integer
+        - description: Age of CStorPoolCluster
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: CStorPoolCluster describes a CStorPoolCluster custom resource.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CStorPoolClusterSpec is the spec for a CStorPoolClusterSpec
+                resource
+              properties:
+                auxResources:
+                  description: AuxResources are the compute resources required by the
+                    cstor-pool pod side car containers.
+                  nullable: true
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                pools:
+                  description: Pools is the spec for pools for various nodes where it
+                    should be created.
+                  items:
+                    description: PoolSpec is the spec for pool on node where it should
+                      be created.
+                    properties:
+                      dataRaidGroups:
+                        description: DataRaidGroups is the raid group configuration
+                          for the given pool.
+                        items:
+                          description: RaidGroup contains the details of a raid group
+                            for the pool
+                          properties:
+                            blockDevices:
+                              items:
+                                description: CStorPoolInstanceBlockDevice contains the
+                                  details of block devices that constitutes a raid group.
+                                properties:
+                                  blockDeviceName:
+                                    description: BlockDeviceName is the name of the
+                                      block device.
+                                    type: string
+                                  capacity:
+                                    description: Capacity is the capacity of the block
+                                      device. It is system generated
+                                    format: int64
+                                    type: integer
+                                  devLink:
+                                    description: DevLink is the dev link for block devices
+                                    type: string
+                                required:
+                                  - blockDeviceName
+                                type: object
+                              type: array
+                          required:
+                            - blockDevices
+                          type: object
+                        type: array
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: NodeSelector is the labels that will be used to
+                          select a node for pool provisioning. Required field
+                        type: object
+                      poolConfig:
+                        description: PoolConfig is the default pool config that applies
+                          to the pool on node.
+                        properties:
+                          auxResources:
+                            description: AuxResources are the compute resources required
+                              by the cstor-pool pod side car containers.
+                            nullable: true
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                          compression:
+                            description: 'Compression to enable compression Optional
+                            -- defaults to off Possible values : lz, off'
+                            type: string
+                          dataRaidGroupType:
+                            description: DataRaidGroupType is the  raid type.
+                            type: string
+                          priorityClassName:
+                            description: PriorityClassName if specified applies to this
+                              pool pod If left empty, DefaultPriorityClassName is applied.
+                              (See CStorPoolClusterSpec.DefaultPriorityClassName) If
+                              both are empty, not priority class is applied.
+                            nullable: true
+                            type: string
+                          resources:
+                            description: Resources are the compute resources required
+                              by the cstor-pool container.
+                            nullable: true
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                          roThresholdLimit:
+                            description: 'ROThresholdLimit is threshold(percentage base)
+                            limit for pool read only mode. If ROThresholdLimit(%)
+                            amount of pool storage is reached then pool will set to
+                            readonly. NOTE: 1. If ROThresholdLimit is set to 100 then
+                            entire    pool storage will be used by default it will
+                            be set to 85%. 2. ROThresholdLimit value will be 0 <=
+                            ROThresholdLimit <= 100.'
+                            nullable: true
+                            type: integer
+                          thickProvision:
+                            description: ThickProvision to enable thick provisioning
+                              Optional -- defaults to false
+                            type: boolean
+                          tolerations:
+                            description: Tolerations, if specified, the pool pod's tolerations.
+                            items:
+                              description: The pod this Toleration is attached to tolerates
+                                any taint that matches the triple <key,value,effect>
+                                using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: Effect indicates the taint effect to
+                                    match. Empty means match all taint effects. When
+                                    specified, allowed values are NoSchedule, PreferNoSchedule
+                                    and NoExecute.
+                                  type: string
+                                key:
+                                  description: Key is the taint key that the toleration
+                                    applies to. Empty means match all taint keys. If
+                                    the key is empty, operator must be Exists; this
+                                    combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: Operator represents a key's relationship
+                                    to the value. Valid operators are Exists and Equal.
+                                    Defaults to Equal. Exists is equivalent to wildcard
+                                    for value, so that a pod can tolerate all taints
+                                    of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: TolerationSeconds represents the period
+                                    of time the toleration (which must be of effect
+                                    NoExecute, otherwise this field is ignored) tolerates
+                                    the taint. By default, it is not set, which means
+                                    tolerate the taint forever (do not evict). Zero
+                                    and negative values will be treated as 0 (evict
+                                    immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: Value is the taint value the toleration
+                                    matches to. If the operator is Exists, the value
+                                    should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            nullable: true
+                            type: array
+                          writeCacheGroupType:
+                            description: WriteCacheGroupType is the write cache raid
+                              type.
+                            type: string
+                        required:
+                          - dataRaidGroupType
+                        type: object
+                      writeCacheRaidGroups:
+                        description: WriteCacheRaidGroups is the write cache raid group.
+                        items:
+                          description: RaidGroup contains the details of a raid group
+                            for the pool
+                          properties:
+                            blockDevices:
+                              items:
+                                description: CStorPoolInstanceBlockDevice contains the
+                                  details of block devices that constitutes a raid group.
+                                properties:
+                                  blockDeviceName:
+                                    description: BlockDeviceName is the name of the
+                                      block device.
+                                    type: string
+                                  capacity:
+                                    description: Capacity is the capacity of the block
+                                      device. It is system generated
+                                    format: int64
+                                    type: integer
+                                  devLink:
+                                    description: DevLink is the dev link for block devices
+                                    type: string
+                                required:
+                                  - blockDeviceName
+                                type: object
+                              type: array
+                          required:
+                            - blockDevices
+                          type: object
+                        nullable: true
+                        type: array
+                    required:
+                      - dataRaidGroups
+                      - nodeSelector
+                    type: object
+                  type: array
+                priorityClassName:
+                  description: DefaultPriorityClassName if specified applies to all
+                    the pool pods in the pool spec if the priorityClass at the pool
+                    level is not specified.
+                  type: string
+                resources:
+                  description: DefaultResources are the compute resources required by
+                    the cstor-pool container. If the resources at PoolConfig is not
+                    specified, this is written to CSPI PoolConfig.
+                  nullable: true
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                tolerations:
+                  description: Tolerations, if specified, are the pool pod's tolerations
+                    If tolerations at PoolConfig is empty, this is written to CSPI PoolConfig.
+                  items:
+                    description: The pod this Toleration is attached to tolerates any
+                      taint that matches the triple <key,value,effect> using the matching
+                      operator <operator>.
+                    properties:
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty,
+                          operator must be Exists; this combination means to match all
+                          values and all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the
+                          value. Valid operators are Exists and Equal. Defaults to Equal.
+                          Exists is equivalent to wildcard for value, so that a pod
+                          can tolerate all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time
+                          the toleration (which must be of effect NoExecute, otherwise
+                          this field is ignored) tolerates the taint. By default, it
+                          is not set, which means tolerate the taint forever (do not
+                          evict). Zero and negative values will be treated as 0 (evict
+                          immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches
+                          to. If the operator is Exists, the value should be empty,
+                          otherwise just a regular string.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+              type: object
+            status:
+              description: CStorPoolClusterStatus represents the latest available observations
+                of a CSPC's current state.
+              properties:
+                conditions:
+                  description: Current state of CSPC.
+                  items:
+                    description: CStorPoolClusterCondition describes the state of a
+                      CSPC at a certain point.
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status
+                          to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: The last time this condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about
+                          the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of CSPC condition.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  nullable: true
+                  type: array
+                desiredInstances:
+                  description: DesiredInstances is the number of CSPI(s) that should
+                    be provisioned.
+                  format: int32
+                  nullable: true
+                  type: integer
+                healthyInstances:
+                  description: HealthyInstances is the number of CSPI(s) that are healthy.
+                  format: int32
+                  nullable: true
+                  type: integer
+                provisionedInstances:
+                  description: ProvisionedInstances is the the number of CSPI present
+                    at the current state.
+                  format: int32
+                  nullable: true
+                  type: integer
+              type: object
+            versionDetails:
+              description: VersionDetails provides the details for upgrade
+              properties:
+                autoUpgrade:
+                  description: If AutoUpgrade is set to true then the resource is upgraded
+                    automatically without any manual steps
+                  type: boolean
+                desired:
+                  description: Desired is the version that we want to upgrade or the
+                    control plane version
+                  type: string
+                status:
+                  description: Status gives the status of reconciliation triggered when
+                    the desired and current version are not same
+                  properties:
+                    current:
+                      description: Current is the version of resource
+                      type: string
+                    dependentsUpgraded:
+                      description: DependentsUpgraded gives the details whether all
+                        children of a resource are upgraded to desired version or not
+                      type: boolean
+                    lastUpdateTime:
+                      description: LastUpdateTime is the time the status was last  updated
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: Message is a human readable message if some error
+                        occurs
+                      type: string
+                    reason:
+                      description: Reason is the actual reason for the error state
+                      type: string
+                    state:
+                      description: State is the state of reconciliation
+                      type: string
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+################################################################################
+###                                                                         ####
+###                       CStorPoolInstance CRD                             ####
+###                                                                         ####
+################################################################################
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: cstorpoolinstances.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorPoolInstance
+    listKind: CStorPoolInstanceList
+    plural: cstorpoolinstances
+    shortNames:
+      - cspi
+    singular: cstorpoolinstance
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Host name where cstorpool instances scheduled
+          jsonPath: .spec.hostName
+          name: HostName
+          type: string
+        - description: The amount of storage space within the pool that has been physically
+            allocated
+          jsonPath: .status.capacity.used
+          name: Allocated
+          priority: 1
+          type: string
+        - description: The amount of usable free space available in the pool
+          jsonPath: .status.capacity.free
+          name: Free
+          type: string
+        - description: Total amount of usable space in pool
+          jsonPath: .status.capacity.total
+          name: Capacity
+          type: string
+        - description: Identifies the pool read only mode
+          jsonPath: .status.readOnly
+          name: ReadOnly
+          type: boolean
+        - description: Represents no.of replicas present in the pool
+          jsonPath: .status.provisionedReplicas
+          name: ProvisionedReplicas
+          type: integer
+        - description: Represents no.of healthy replicas present in the pool
+          jsonPath: .status.healthyReplicas
+          name: HealthyReplicas
+          type: integer
+        - description: Represents the type of the storage pool
+          jsonPath: .spec.poolConfig.dataRaidGroupType
+          name: Type
+          priority: 1
+          type: string
+        - description: Identifies the current health of the pool
+          jsonPath: .status.phase
+          name: Status
+          type: string
+        - description: Age of CStorPoolInstance
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: CStorPoolInstance describes a cstor pool instance resource.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec is the specification of the cstorpoolinstance resource.
+              properties:
+                dataRaidGroups:
+                  description: DataRaidGroups is the raid group configuration for the
+                    given pool.
+                  items:
+                    description: RaidGroup contains the details of a raid group for
+                      the pool
+                    properties:
+                      blockDevices:
+                        items:
+                          description: CStorPoolInstanceBlockDevice contains the details
+                            of block devices that constitutes a raid group.
+                          properties:
+                            blockDeviceName:
+                              description: BlockDeviceName is the name of the block
+                                device.
+                              type: string
+                            capacity:
+                              description: Capacity is the capacity of the block device.
+                                It is system generated
+                              format: int64
+                              type: integer
+                            devLink:
+                              description: DevLink is the dev link for block devices
+                              type: string
+                          required:
+                            - blockDeviceName
+                          type: object
+                        type: array
+                    required:
+                      - blockDevices
+                    type: object
+                  type: array
+                hostName:
+                  description: HostName is the name of kubernetes node where the pool
+                    should be created.
+                  type: string
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  description: NodeSelector is the labels that will be used to select
+                    a node for pool provisioning. Required field
+                  type: object
+                poolConfig:
+                  description: PoolConfig is the default pool config that applies to
+                    the pool on node.
+                  properties:
+                    auxResources:
+                      description: AuxResources are the compute resources required by
+                        the cstor-pool pod side car containers.
+                      nullable: true
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    compression:
+                      description: 'Compression to enable compression Optional -- defaults
+                      to off Possible values : lz, off'
+                      type: string
+                    dataRaidGroupType:
+                      description: DataRaidGroupType is the  raid type.
+                      type: string
+                    priorityClassName:
+                      description: PriorityClassName if specified applies to this pool
+                        pod If left empty, DefaultPriorityClassName is applied. (See
+                        CStorPoolClusterSpec.DefaultPriorityClassName) If both are empty,
+                        not priority class is applied.
+                      nullable: true
+                      type: string
+                    resources:
+                      description: Resources are the compute resources required by the
+                        cstor-pool container.
+                      nullable: true
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    roThresholdLimit:
+                      description: 'ROThresholdLimit is threshold(percentage base) limit
+                      for pool read only mode. If ROThresholdLimit(%) amount of pool
+                      storage is reached then pool will set to readonly. NOTE: 1.
+                      If ROThresholdLimit is set to 100 then entire    pool storage
+                      will be used by default it will be set to 85%. 2. ROThresholdLimit
+                      value will be 0 <= ROThresholdLimit <= 100.'
+                      nullable: true
+                      type: integer
+                    thickProvision:
+                      description: ThickProvision to enable thick provisioning Optional
+                        -- defaults to false
+                      type: boolean
+                    tolerations:
+                      description: Tolerations, if specified, the pool pod's tolerations.
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified, allowed
+                              values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies
+                              to. Empty means match all taint keys. If the key is empty,
+                              operator must be Exists; this combination means to match
+                              all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to
+                              the value. Valid operators are Exists and Equal. Defaults
+                              to Equal. Exists is equivalent to wildcard for value,
+                              so that a pod can tolerate all taints of a particular
+                              category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the taint
+                              forever (do not evict). Zero and negative values will
+                              be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                    writeCacheGroupType:
+                      description: WriteCacheGroupType is the write cache raid type.
+                      type: string
+                  required:
+                    - dataRaidGroupType
+                  type: object
+                writeCacheRaidGroups:
+                  description: WriteCacheRaidGroups is the write cache raid group.
+                  items:
+                    description: RaidGroup contains the details of a raid group for
+                      the pool
+                    properties:
+                      blockDevices:
+                        items:
+                          description: CStorPoolInstanceBlockDevice contains the details
+                            of block devices that constitutes a raid group.
+                          properties:
+                            blockDeviceName:
+                              description: BlockDeviceName is the name of the block
+                                device.
+                              type: string
+                            capacity:
+                              description: Capacity is the capacity of the block device.
+                                It is system generated
+                              format: int64
+                              type: integer
+                            devLink:
+                              description: DevLink is the dev link for block devices
+                              type: string
+                          required:
+                            - blockDeviceName
+                          type: object
+                        type: array
+                    required:
+                      - blockDevices
+                    type: object
+                  nullable: true
+                  type: array
+              required:
+                - dataRaidGroups
+                - nodeSelector
+              type: object
+            status:
+              description: Status is the possible statuses of the cstorpoolinstance
+                resource.
+              properties:
+                capacity:
+                  description: Capacity describes the capacity details of a cstor pool
+                  properties:
+                    free:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Amount of usable space in the pool after excluding
+                        metadata and raid parity
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    total:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Sum of usable capacity in all the data raidgroups
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    used:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Amount of physical data (and its metadata) written
+                        to pool after applying compression, etc..,
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    zfs:
+                      description: ZFSCapacityAttributes contains advanced information
+                        about pool capacity details
+                      properties:
+                        logicalUsed:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: LogicalUsed is the amount of space that is "logically"
+                            consumed by this pool and all its descendents. The logical
+                            space ignores the effect of the compression and copies properties,
+                            giving a quantity closer to the amount of data that applications
+                            see. However, it does include space consumed by metadata.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      required:
+                        - logicalUsed
+                      type: object
+                  required:
+                    - free
+                    - total
+                    - used
+                    - zfs
+                  type: object
+                conditions:
+                  description: Current state of CSPI with details.
+                  items:
+                    description: CSPIConditionType describes the state of a CSPI at
+                      a certain point.
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status
+                          to another.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: The last time this condition was updated.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about
+                          the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of CSPC condition.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                healthyReplicas:
+                  description: HealthyReplicas describes the total count of healthy
+                    Volume Replicas in the cstor pool
+                  format: int32
+                  type: integer
+                phase:
+                  description: ' The phase of a CStorPool is a simple, high-level summary
+                  of the pool state on the  node.'
+                  type: string
+                provisionedReplicas:
+                  description: ProvisionedReplicas describes the total count of Volume
+                    Replicas present in the cstor pool
+                  format: int32
+                  type: integer
+                readOnly:
+                  description: ReadOnly if pool is readOnly or not
+                  type: boolean
+              required:
+                - healthyReplicas
+                - provisionedReplicas
+                - readOnly
+              type: object
+            versionDetails:
+              description: VersionDetails is the openebs version.
+              properties:
+                autoUpgrade:
+                  description: If AutoUpgrade is set to true then the resource is upgraded
+                    automatically without any manual steps
+                  type: boolean
+                desired:
+                  description: Desired is the version that we want to upgrade or the
+                    control plane version
+                  type: string
+                status:
+                  description: Status gives the status of reconciliation triggered when
+                    the desired and current version are not same
+                  properties:
+                    current:
+                      description: Current is the version of resource
+                      type: string
+                    dependentsUpgraded:
+                      description: DependentsUpgraded gives the details whether all
+                        children of a resource are upgraded to desired version or not
+                      type: boolean
+                    lastUpdateTime:
+                      description: LastUpdateTime is the time the status was last  updated
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: Message is a human readable message if some error
+                        occurs
+                      type: string
+                    reason:
+                      description: Reason is the actual reason for the error state
+                      type: string
+                    state:
+                      description: State is the state of reconciliation
+                      type: string
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+#########################################################################
+####                                                                #####
+####                         CStorVolumeConfig CRD                  #####
+####                                                                #####
+#########################################################################
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: cstorvolumeconfigs.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolumeConfig
+    listKind: CStorVolumeConfigList
+    plural: cstorvolumeconfigs
+    shortNames:
+      - cvc
+    singular: cstorvolumeconfig
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Identifies the volume capacity
+          jsonPath: .status.capacity.storage
+          name: Capacity
+          type: string
+        - description: Identifies the volume provisioning status
+          jsonPath: .status.phase
+          name: Status
+          type: string
+        - description: Age of CStorVolumeReplica
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: CStorVolumeConfig describes a cstor volume config resource created
+            as custom resource. CStorVolumeConfig is a request for creating cstor volume
+            related resources like deployment, svc etc.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            publish:
+              description: Publish contains info related to attachment of a volume to
+                a node. i.e. NodeId etc.
+              properties:
+                nodeId:
+                  description: NodeID contains publish info related to attachment of
+                    a volume to a node.
+                  type: string
+              type: object
+            spec:
+              description: Spec defines a specification of a cstor volume config required
+                to provisione cstor volume resources
+              properties:
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity represents the actual resources of the underlying
+                    cstor volume.
+                  type: object
+                cstorVolumeRef:
+                  description: CStorVolumeRef has the information about where CstorVolumeClaim
+                    is created from.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                cstorVolumeSource:
+                  description: CStorVolumeSource contains the source volumeName@snapShotname
+                    combaination.  This will be filled only if it is a clone creation.
+                  type: string
+                policy:
+                  description: Policy contains volume specific required policies target
+                    and replicas
+                  properties:
+                    provision:
+                      description: replicaAffinity is set to true then volume replica
+                        resources need to be distributed across the pool instances
+                      properties:
+                        blockSize:
+                          description: BlockSize is the logical block size in multiple
+                            of 512 bytes BlockSize specifies the block size of the volume.
+                            The blocksize cannot be changed once the volume has been
+                            written, so it should be set at volume creation time. The
+                            default blocksize for volumes is 4 Kbytes. Any power of
+                            2 from 512 bytes to 128 Kbytes is valid.
+                          format: int32
+                          type: integer
+                        replicaAffinity:
+                          description: replicaAffinity is set to true then volume replica
+                            resources need to be distributed across the cstor pool instances
+                            based on the given topology
+                          type: boolean
+                      required:
+                        - replicaAffinity
+                      type: object
+                    replica:
+                      description: ReplicaSpec represents configuration related to replicas
+                        resources
+                      properties:
+                        compression:
+                          description: The zle compression algorithm compresses runs
+                            of zeros.
+                          type: string
+                        zvolWorkers:
+                          description: IOWorkers represents number of threads that executes
+                            client IOs
+                          type: string
+                      type: object
+                    replicaPoolInfo:
+                      description: 'ReplicaPoolInfo holds the pool information of volume
+                      replicas. Ex: If volume is provisioned on which CStor pool volume
+                      replicas exist'
+                      items:
+                        description: ReplicaPoolInfo represents the pool information
+                          of volume replica
+                        properties:
+                          poolName:
+                            description: PoolName represents the pool name where volume
+                              replica exists
+                            type: string
+                        required:
+                          - poolName
+                        type: object
+                      type: array
+                    target:
+                      description: TargetSpec represents configuration related to cstor
+                        target and its resources
+                      properties:
+                        affinity:
+                          description: PodAffinity if specified, are the target pod's
+                            affinities
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to a pod label update),
+                                the system may or may not try to eventually evict the
+                                pod from its node. When there are multiple elements,
+                                the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        auxResources:
+                          description: AuxResources are the compute resources required
+                            by the cstor-target pod side car containers.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        luWorkers:
+                          description: IOWorkers sets the number of threads that are
+                            working on above queue
+                          format: int64
+                          type: integer
+                        monitor:
+                          description: Monitor enables or disables the target exporter
+                            sidecar
+                          type: boolean
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          description: NodeSelector is the labels that will be used
+                            to select a node for target pod scheduleing Required field
+                          type: object
+                        priorityClassName:
+                          description: PriorityClassName if specified applies to this
+                            target pod If left empty, no priority class is applied.
+                          type: string
+                        queueDepth:
+                          description: QueueDepth sets the queue size at iSCSI target
+                            which limits the ongoing IO count from client
+                          type: string
+                        replicationFactor:
+                          description: ReplicationFactor represents maximum number of
+                            replicas that are allowed to connect to the target
+                          format: int64
+                          type: integer
+                        resources:
+                          description: Resources are the compute resources required
+                            by the cstor-target container.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        tolerations:
+                          description: Tolerations, if specified, are the target pod's
+                            tolerations
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect> using
+                              the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match.
+                                  Empty means match all taint effects. When specified,
+                                  allowed values are NoSchedule, PreferNoSchedule and
+                                  NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If the
+                                  key is empty, operator must be Exists; this combination
+                                  means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints of
+                                  a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect NoExecute,
+                                  otherwise this field is ignored) tolerates the taint.
+                                  By default, it is not set, which means tolerate the
+                                  taint forever (do not evict). Zero and negative values
+                                  will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value should
+                                  be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                provision:
+                  description: Provision represents the initial volume configuration
+                    for the underlying cstor volume based on the persistent volume request
+                    by user. Provision properties are immutable
+                  properties:
+                    capacity:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Capacity represents initial capacity of volume replica
+                        required during volume clone operations to maintain some metadata
+                        info related to child resources like snapshot, cloned volumes.
+                      type: object
+                    replicaCount:
+                      description: ReplicaCount represents initial cstor volume replica
+                        count, its will not be updated later on based on scale up/down
+                        operations, only readonly operations and validations.
+                      type: integer
+                  required:
+                    - capacity
+                    - replicaCount
+                  type: object
+              required:
+                - capacity
+                - policy
+                - provision
+              type: object
+            status:
+              description: Status represents the current information/status for the
+                cstor volume config, populated by the controller.
+              properties:
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity the actual resources of the underlying volume.
+                  type: object
+                condition:
+                  items:
+                    description: CStorVolumeConfigCondition contains details about state
+                      of cstor volume
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status
+                          to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about
+                          last transition.
+                        type: string
+                      reason:
+                        description: Reason is a brief CamelCase string that describes
+                          any failure
+                        type: string
+                      type:
+                        description: Current Condition of cstor volume config. If underlying
+                          persistent volume is being resized then the Condition will
+                          be set to 'ResizeStarted' etc
+                        type: string
+                    required:
+                      - message
+                      - reason
+                      - type
+                    type: object
+                  type: array
+                phase:
+                  description: Phase represents the current phase of CStorVolumeConfig.
+                  type: string
+                poolInfo:
+                  description: PoolInfo represents current pool names where volume replicas
+                    exists
+                  items:
+                    type: string
+                  type: array
+              type: object
+            versionDetails:
+              description: VersionDetails provides the details for upgrade
+              properties:
+                autoUpgrade:
+                  description: If AutoUpgrade is set to true then the resource is upgraded
+                    automatically without any manual steps
+                  type: boolean
+                desired:
+                  description: Desired is the version that we want to upgrade or the
+                    control plane version
+                  type: string
+                status:
+                  description: Status gives the status of reconciliation triggered when
+                    the desired and current version are not same
+                  properties:
+                    current:
+                      description: Current is the version of resource
+                      type: string
+                    dependentsUpgraded:
+                      description: DependentsUpgraded gives the details whether all
+                        children of a resource are upgraded to desired version or not
+                      type: boolean
+                    lastUpdateTime:
+                      description: LastUpdateTime is the time the status was last  updated
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: Message is a human readable message if some error
+                        occurs
+                      type: string
+                    reason:
+                      description: Reason is the actual reason for the error state
+                      type: string
+                    state:
+                      description: State is the state of reconciliation
+                      type: string
+                  type: object
+              type: object
+          required:
+            - spec
+            - status
+            - versionDetails
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+################################################################
+####                                                       #####
+####                  CStorVolumePolicies                  #####
+####                                                       #####
+################################################################
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: cstorvolumepolicies.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolumePolicy
+    listKind: CStorVolumePolicyList
+    plural: cstorvolumepolicies
+    shortNames:
+      - cvp
+    singular: cstorvolumepolicy
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: CStorVolumePolicy describes a configuration required for cstor
+            volume resources
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines a configuration info of a cstor volume required
+                to provisione cstor volume resources
+              properties:
+                provision:
+                  description: replicaAffinity is set to true then volume replica resources
+                    need to be distributed across the pool instances
+                  properties:
+                    blockSize:
+                      description: BlockSize is the logical block size in multiple of
+                        512 bytes BlockSize specifies the block size of the volume.
+                        The blocksize cannot be changed once the volume has been written,
+                        so it should be set at volume creation time. The default blocksize
+                        for volumes is 4 Kbytes. Any power of 2 from 512 bytes to 128
+                        Kbytes is valid.
+                      format: int32
+                      type: integer
+                    replicaAffinity:
+                      description: replicaAffinity is set to true then volume replica
+                        resources need to be distributed across the cstor pool instances
+                        based on the given topology
+                      type: boolean
+                  required:
+                    - replicaAffinity
+                  type: object
+                replica:
+                  description: ReplicaSpec represents configuration related to replicas
+                    resources
+                  properties:
+                    compression:
+                      description: The zle compression algorithm compresses runs of
+                        zeros.
+                      type: string
+                    zvolWorkers:
+                      description: IOWorkers represents number of threads that executes
+                        client IOs
+                      type: string
+                  type: object
+                replicaPoolInfo:
+                  description: 'ReplicaPoolInfo holds the pool information of volume
+                  replicas. Ex: If volume is provisioned on which CStor pool volume
+                  replicas exist'
+                  items:
+                    description: ReplicaPoolInfo represents the pool information of
+                      volume replica
+                    properties:
+                      poolName:
+                        description: PoolName represents the pool name where volume
+                          replica exists
+                        type: string
+                    required:
+                      - poolName
+                    type: object
+                  type: array
+                target:
+                  description: TargetSpec represents configuration related to cstor
+                    target and its resources
+                  properties:
+                    affinity:
+                      description: PodAffinity if specified, are the target pod's affinities
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods to
+                            nodes that satisfy the affinity expressions specified by
+                            this field, but it may choose a node that violates one or
+                            more of the expressions. The node that is most preferred
+                            is the one with the greatest sum of weights, i.e. for each
+                            node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements of
+                            this field and adding "weight" to the sum if the node has
+                            pods which matches the corresponding podAffinityTerm; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not be
+                            scheduled onto the node. If the affinity requirements specified
+                            by this field cease to be met at some point during pod execution
+                            (e.g. due to a pod label update), the system may or may
+                            not try to eventually evict the pod from its node. When
+                            there are multiple elements, the lists of nodes corresponding
+                            to each podAffinityTerm are intersected, i.e. all terms
+                            must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not co-located
+                              (anti-affinity) with, where co-located is defined as running
+                              on a node whose value of the label with key <topologyKey>
+                              matches that of any node on which a pod of the set of
+                              pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the
+                                            operator is Exists or DoesNotExist, the
+                                            values array must be empty. This array is
+                                            replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value". The
+                                      requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces the
+                                  labelSelector applies to (matches against); null or
+                                  empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where
+                                  co-located is defined as running on a node whose value
+                                  of the label with key topologyKey matches that of
+                                  any node on which any of the selected pods is running.
+                                  Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    auxResources:
+                      description: AuxResources are the compute resources required by
+                        the cstor-target pod side car containers.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    luWorkers:
+                      description: IOWorkers sets the number of threads that are working
+                        on above queue
+                      format: int64
+                      type: integer
+                    monitor:
+                      description: Monitor enables or disables the target exporter sidecar
+                      type: boolean
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: NodeSelector is the labels that will be used to select
+                        a node for target pod scheduleing Required field
+                      type: object
+                    priorityClassName:
+                      description: PriorityClassName if specified applies to this target
+                        pod If left empty, no priority class is applied.
+                      type: string
+                    queueDepth:
+                      description: QueueDepth sets the queue size at iSCSI target which
+                        limits the ongoing IO count from client
+                      type: string
+                    replicationFactor:
+                      description: ReplicationFactor represents maximum number of replicas
+                        that are allowed to connect to the target
+                      format: int64
+                      type: integer
+                    resources:
+                      description: Resources are the compute resources required by the
+                        cstor-target container.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    tolerations:
+                      description: Tolerations, if specified, are the target pod's tolerations
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified, allowed
+                              values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies
+                              to. Empty means match all taint keys. If the key is empty,
+                              operator must be Exists; this combination means to match
+                              all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to
+                              the value. Valid operators are Exists and Equal. Defaults
+                              to Equal. Exists is equivalent to wildcard for value,
+                              so that a pod can tolerate all taints of a particular
+                              category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the taint
+                              forever (do not evict). Zero and negative values will
+                              be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            status:
+              description: CStorVolumePolicyStatus is for handling status of CstorVolumePolicy
+              properties:
+                phase:
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+#############################################################################################
+###                                                                                    ######
+###                    CStorVolumeReplicas CRD                                         ######
+###                                                                                    ######
+#############################################################################################
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: cstorvolumereplicas.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolumeReplica
+    listKind: CStorVolumeReplicaList
+    plural: cstorvolumereplicas
+    shortNames:
+      - cvr
+    singular: cstorvolumereplica
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The amount of disk space consumed by a dataset and all its descendents
+          jsonPath: .status.capacity.total
+          name: Allocated
+          type: string
+        - description: The amount of space that is logically consumed by this dataset
+          jsonPath: .status.capacity.used
+          name: Used
+          type: string
+        - description: Identifies the current state of the replicas
+          jsonPath: .status.phase
+          name: Status
+          type: string
+        - description: Age of CStorVolumeReplica
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: CStorVolumeReplica describes a cstor volume resource created
+            as custom resource
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CStorVolumeReplicaSpec is the spec for a CStorVolumeReplica
+                resource
+              properties:
+                blockSize:
+                  description: BlockSize is the logical block size in multiple of 512
+                    bytes BlockSize specifies the block size of the volume. The blocksize
+                    cannot be changed once the volume has been written, so it should
+                    be set at volume creation time. The default blocksize for volumes
+                    is 4 Kbytes. Any power of 2 from 512 bytes to 128 Kbytes is valid.
+                  format: int32
+                  type: integer
+                capacity:
+                  description: Represents the actual capacity of the underlying volume
+                  type: string
+                compression:
+                  description: 'Controls the compression algorithm used for this volumes
+                  examples: on|off|gzip|gzip-N|lz4|lzjb|zle'
+                  type: string
+                replicaid:
+                  description: ReplicaID is unique number to identify the replica
+                  type: string
+                targetIP:
+                  description: TargetIP represents iscsi target IP through which replica
+                    cummunicates IO workloads and other volume operations like snapshot
+                    and resize requests
+                  type: string
+                zvolWorkers:
+                  description: ZvolWorkers represents number of threads that executes
+                    client IOs
+                  type: string
+              type: object
+            status:
+              description: CStorVolumeReplicaStatus is for handling status of cvr.
+              properties:
+                capacity:
+                  description: CStorVolumeCapacityDetails represents capacity info of
+                    replica
+                  properties:
+                    total:
+                      description: The amount of space consumed by this volume replica
+                        and all its descendents
+                      type: string
+                    used:
+                      description: The amount of space that is "logically" accessible
+                        by this dataset. The logical space ignores the effect of the
+                        compression and copies properties, giving a quantity closer
+                        to the amount of data that applications see.  However, it does
+                        include space consumed by metadata
+                      type: string
+                  required:
+                    - total
+                    - used
+                  type: object
+                lastTransitionTime:
+                  description: LastTransitionTime refers to the time when the phase
+                    changes
+                  format: date-time
+                  nullable: true
+                  type: string
+                lastUpdateTime:
+                  description: The last updated time
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: A human readable message indicating details about the
+                    transition.
+                  type: string
+                pendingSnapshots:
+                  additionalProperties:
+                    description: CStorSnapshotInfo represents the snapshot information
+                      related to particular snapshot
+                    properties:
+                      logicalReferenced:
+                        description: LogicalReferenced describes the amount of space
+                          that is "logically" accessable by this snapshot. This logical
+                          space ignores the effect of the compression and copies properties,
+                          giving a quantity closer to the amount of data that application
+                          see. It also includes space consumed by metadata.
+                        format: int64
+                        type: integer
+                    required:
+                      - logicalReferenced
+                    type: object
+                  description: PendingSnapshots contains list of pending snapshots that
+                    are not yet available on this replica
+                  type: object
+                phase:
+                  description: CStorVolumeReplicaPhase is to holds different phases
+                    of replica
+                  type: string
+                snapshots:
+                  additionalProperties:
+                    description: CStorSnapshotInfo represents the snapshot information
+                      related to particular snapshot
+                    properties:
+                      logicalReferenced:
+                        description: LogicalReferenced describes the amount of space
+                          that is "logically" accessable by this snapshot. This logical
+                          space ignores the effect of the compression and copies properties,
+                          giving a quantity closer to the amount of data that application
+                          see. It also includes space consumed by metadata.
+                        format: int64
+                        type: integer
+                    required:
+                      - logicalReferenced
+                    type: object
+                  description: Snapshots contains list of snapshots, and their properties,
+                    created on CVR
+                  type: object
+              type: object
+            versionDetails:
+              description: VersionDetails provides the details for upgrade
+              properties:
+                autoUpgrade:
+                  description: If AutoUpgrade is set to true then the resource is upgraded
+                    automatically without any manual steps
+                  type: boolean
+                desired:
+                  description: Desired is the version that we want to upgrade or the
+                    control plane version
+                  type: string
+                status:
+                  description: Status gives the status of reconciliation triggered when
+                    the desired and current version are not same
+                  properties:
+                    current:
+                      description: Current is the version of resource
+                      type: string
+                    dependentsUpgraded:
+                      description: DependentsUpgraded gives the details whether all
+                        children of a resource are upgraded to desired version or not
+                      type: boolean
+                    lastUpdateTime:
+                      description: LastUpdateTime is the time the status was last  updated
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: Message is a human readable message if some error
+                        occurs
+                      type: string
+                    reason:
+                      description: Reason is the actual reason for the error state
+                      type: string
+                    state:
+                      description: State is the state of reconciliation
+                      type: string
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+###############################################################################
+####                                                                       ####
+####               CStorVolume CRD                                         ####
+####                                                                       ####
+###############################################################################
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: cstorvolumes.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolume
+    listKind: CStorVolumeList
+    plural: cstorvolumes
+    shortNames:
+      - cv
+    singular: cstorvolume
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Current volume capacity
+          jsonPath: .status.capacity
+          name: Capacity
+          type: string
+        - description: Identifies the current health of the volume
+          jsonPath: .status.phase
+          name: Status
+          type: string
+        - description: Age of CStorVolume
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: CStorVolume describes a cstor volume resource created as custom
+            resource
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CStorVolumeSpec is the spec for a CStorVolume resource
+              properties:
+                capacity:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: Capacity represents the desired size of the underlying
+                    volume.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                consistencyFactor:
+                  description: ConsistencyFactor is minimum number of volume replicas
+                    i.e. `RF/2 + 1` has to be connected to the target for write operations.
+                    Basically more then 50% of replica has to be connected to target.
+                  type: integer
+                desiredReplicationFactor:
+                  description: DesiredReplicationFactor represents maximum number of
+                    replicas that are allowed to connect to the target. Required for
+                    scale operations
+                  type: integer
+                iqn:
+                  description: Target iSCSI Qualified Name.combination of nodeBase
+                  type: string
+                replicaDetails:
+                  description: ReplicaDetails refers to the trusty replica information
+                  properties:
+                    knownReplicas:
+                      additionalProperties:
+                        type: string
+                      description: KnownReplicas represents the replicas that target
+                        can trust to read data
+                      type: object
+                  type: object
+                replicationFactor:
+                  description: ReplicationFactor represents number of volume replica
+                    created during volume provisioning connect to the target
+                  type: integer
+                targetIP:
+                  description: TargetIP IP of the iSCSI target service
+                  type: string
+                targetPort:
+                  description: iSCSI Target Port typically TCP ports 3260
+                  type: string
+                targetPortal:
+                  description: iSCSI Target Portal. The Portal is combination of IP:port
+                    (typically TCP ports 3260)
+                  type: string
+              type: object
+            status:
+              description: CStorVolumeStatus is for handling status of cvr.
+              properties:
+                capacity:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: Represents the actual capacity of the underlying volume.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                conditions:
+                  description: Current Condition of cstorvolume. If underlying persistent
+                    volume is being resized then the Condition will be set to 'ResizePending'.
+                  items:
+                    description: CStorVolumeCondition contains details about state of
+                      cstorvolume
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status
+                          to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about
+                          last transition.
+                        type: string
+                      reason:
+                        description: Unique, this should be a short, machine understandable
+                          string that gives the reason for condition's last transition.
+                          If it reports "ResizePending" that means the underlying cstorvolume
+                          is being resized.
+                        type: string
+                      status:
+                        description: ConditionStatus states in which state condition
+                          is present
+                        type: string
+                      type:
+                        description: CStorVolumeConditionType is a valid value of CStorVolumeCondition.Type
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastTransitionTime:
+                  description: LastTransitionTime refers to the time when the phase
+                    changes
+                  format: date-time
+                  nullable: true
+                  type: string
+                lastUpdateTime:
+                  description: LastUpdateTime refers to the time when last status updated
+                    due to any operations
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: A human-readable message indicating details about why
+                    the volume is in this state.
+                  type: string
+                phase:
+                  description: CStorVolumePhase is to hold result of action.
+                  type: string
+                replicaDetails:
+                  description: ReplicaDetails refers to the trusty replica information
+                  properties:
+                    knownReplicas:
+                      additionalProperties:
+                        type: string
+                      description: KnownReplicas represents the replicas that target
+                        can trust to read data
+                      type: object
+                  type: object
+                replicaStatuses:
+                  items:
+                    description: ReplicaStatus stores the status of replicas
+                    properties:
+                      checkpointedIOSeq:
+                        description: Represents IO number of replica persisted on the
+                          disk
+                        type: string
+                      inflightRead:
+                        description: Ongoing reads I/O from target to replica
+                        type: string
+                      inflightSync:
+                        description: Ongoing sync I/O from target to replica
+                        type: string
+                      inflightWrite:
+                        description: ongoing writes I/O from target to replica
+                        type: string
+                      mode:
+                        description: Mode represents replica status i.e. Healthy, Degraded
+                        type: string
+                      quorum:
+                        description: 'Quorum indicates wheather data wrtitten to the
+                        replica is lost or exists. "0" means: data has been lost(
+                        might be ephimeral case) and will recostruct data from other
+                        Healthy replicas in a write-only mode 1 means: written data
+                        is exists on replica'
+                        type: string
+                      replicaId:
+                        description: ID is replica unique identifier
+                        type: string
+                      upTime:
+                        description: time since the replica connected to target
+                        type: integer
+                    required:
+                      - checkpointedIOSeq
+                      - inflightRead
+                      - inflightSync
+                      - inflightWrite
+                      - mode
+                      - quorum
+                      - replicaId
+                      - upTime
+                    type: object
+                  type: array
+              type: object
+            versionDetails:
+              description: VersionDetails provides the details for upgrade
+              properties:
+                autoUpgrade:
+                  description: If AutoUpgrade is set to true then the resource is upgraded
+                    automatically without any manual steps
+                  type: boolean
+                desired:
+                  description: Desired is the version that we want to upgrade or the
+                    control plane version
+                  type: string
+                status:
+                  description: Status gives the status of reconciliation triggered when
+                    the desired and current version are not same
+                  properties:
+                    current:
+                      description: Current is the version of resource
+                      type: string
+                    dependentsUpgraded:
+                      description: DependentsUpgraded gives the details whether all
+                        children of a resource are upgraded to desired version or not
+                      type: boolean
+                    lastUpdateTime:
+                      description: LastUpdateTime is the time the status was last  updated
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: Message is a human readable message if some error
+                        occurs
+                      type: string
+                    reason:
+                      description: Reason is the actual reason for the error state
+                      type: string
+                    state:
+                      description: State is the state of reconciliation
+                      type: string
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+############################################################
+####                                                    ####
+####                   CStorBackup CRD                  ####
+####                                                    ####
+############################################################
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: cstorbackups.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorBackup
+    listKind: CStorBackupList
+    plural: cstorbackups
+    shortNames:
+      - cbackup
+    singular: cstorbackup
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Name of the volume for which this backup is destined
+          jsonPath: .spec.volumeName
+          name: Volume
+          type: string
+        - description: Name of the backup or scheduled backup
+          jsonPath: .spec.backupName
+          name: Backup/Schedule
+          type: string
+        - description: Identifies the phase of the backup
+          jsonPath: .status
+          name: Status
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: CStorBackup describes a cstor backup resource created as a custom
+            resource
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CStorBackupSpec is the spec for a CStorBackup resource
+              properties:
+                backupDest:
+                  description: BackupDest is the remote address for backup transfer
+                  type: string
+                backupName:
+                  description: BackupName is the name of the backup or scheduled backup
+                  type: string
+                localSnap:
+                  description: LocalSnap is the flag to enable local snapshot only
+                  type: boolean
+                prevSnapName:
+                  description: PrevSnapName is the last completed-backup's snapshot
+                    name
+                  type: string
+                snapName:
+                  description: SnapName is the name of the current backup snapshot
+                  type: string
+                volumeName:
+                  description: VolumeName is the name of the volume for which this backup
+                    is destined
+                  type: string
+              required:
+                - backupName
+                - snapName
+                - volumeName
+              type: object
+            status:
+              description: CStorBackupStatus is a string type that represents the status
+                of the backup
+              type: string
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+############################################################
+####                                                    ####
+####             CStorCompletedBackup CRD               ####
+####                                                    ####
+############################################################
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: cstorcompletedbackups.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorCompletedBackup
+    listKind: CStorCompletedBackupList
+    plural: cstorcompletedbackups
+    shortNames:
+      - ccompletedbackup
+    singular: cstorcompletedbackup
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Volume name on which backup is performed
+          jsonPath: .spec.volumeName
+          name: Volume
+          type: string
+        - description: Name of the backup or scheduled backup
+          jsonPath: .spec.backupName
+          name: Backup/Schedule
+          type: string
+        - description: Last successfully backup snapshot
+          jsonPath: .spec.lastSnapName
+          name: LastSnap
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: CStorCompletedBackup describes a cstor completed-backup resource
+            created as custom resource
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CStorCompletedBackupSpec is the spec for a CStorBackup resource
+              properties:
+                backupName:
+                  description: BackupName is the name of backup or scheduled backup
+                  type: string
+                lastSnapName:
+                  description: LastSnapName is the name of last completed-backup's snapshot
+                    name
+                  type: string
+                secondLastSnapName:
+                  description: SecondLastSnapName is the name of second last 'successfully'
+                    completed-backup's snapshot
+                  type: string
+                volumeName:
+                  description: VolumeName is the name of volume for which this backup
+                    is destined
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+############################################################
+####                                                    ####
+####             CStorRestore CRD                       ####
+####                                                    ####
+############################################################
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: cstorrestores.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorRestore
+    listKind: CStorRestoreList
+    plural: cstorrestores
+    shortNames:
+      - crestore
+    singular: cstorrestore
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Name of the snapshot which is restored
+          jsonPath: .spec.restoreName
+          name: Backup
+          type: string
+        - description: Volume on which restore is performed
+          jsonPath: .spec.volumeName
+          name: Volume
+          type: string
+        - description: Identifies the state of the restore
+          jsonPath: .status
+          name: Status
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: CStorRestore describes a cstor restore resource created as a
+            custom resource
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CStorRestoreSpec is the spec for a CStorRestore resource
+              properties:
+                localRestore:
+                  description: Local defines whether restore is from local/remote
+                  type: boolean
+                maxretrycount:
+                  description: MaxRestoreRetryCount is the maximum number of attempt,
+                    will be performed to restore
+                  type: integer
+                restoreName:
+                  description: RestoreName holds restore name
+                  type: string
+                restoreSrc:
+                  description: RestoreSrc can be ip:port in case of restore from remote
+                    or volumeName in case of local restore
+                  type: string
+                retrycount:
+                  description: RetryCount represents the number of restore attempts
+                    performed for the restore
+                  type: integer
+                size:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: Size represents the size of a snapshot to restore
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                storageClass:
+                  description: StorageClass represents name of StorageClass of restore
+                    volume
+                  type: string
+                volumeName:
+                  description: VolumeName is used to restore the data to corresponding
+                    volume
+                  type: string
+              required:
+                - restoreName
+                - restoreSrc
+                - volumeName
+              type: object
+            status:
+              description: CStorRestoreStatus is a string type that represents the status
+                of the restore
+              type: string
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: upgradetasks.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: UpgradeTask
+    listKind: UpgradeTaskList
+    plural: upgradetasks
+    singular: upgradetask
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: UpgradeTask represents an upgrade task
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec i.e. specifications of the UpgradeTask
+              properties:
+                cstorPool:
+                  description: CStorPool contains the details of the cstor pool to be
+                    upgraded
+                  properties:
+                    options:
+                      description: Options can be used to change the default behaviour
+                        of upgrade
+                      properties:
+                        ignoreStepsOnError:
+                          description: IgnoreStepsOnError allows to ignore steps which
+                            failed
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    poolName:
+                      description: PoolName contains the name of the cstor pool to be
+                        upgraded
+                      type: string
+                  type: object
+                cstorPoolCluster:
+                  description: CStorPoolCluster contains the details of the storage
+                    pool claim to be upgraded
+                  properties:
+                    cspcName:
+                      description: CSPCName contains the name of the storage pool claim
+                        to be upgraded
+                      type: string
+                    options:
+                      description: Options can be used to change the default behaviour
+                        of upgrade
+                      properties:
+                        ignoreStepsOnError:
+                          description: IgnoreStepsOnError allows to ignore steps which
+                            failed
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                  type: object
+                cstorPoolInstance:
+                  description: CStorPoolInstance contains the details of the cstor pool
+                    to be upgraded
+                  properties:
+                    cspiName:
+                      description: CSPCName contains the name of the storage pool claim
+                        to be upgraded
+                      type: string
+                    options:
+                      description: Options can be used to change the default behaviour
+                        of upgrade
+                      properties:
+                        ignoreStepsOnError:
+                          description: IgnoreStepsOnError allows to ignore steps which
+                            failed
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                  type: object
+                cstorVolume:
+                  description: CStorVolume contains the details of the cstor volume
+                    to be upgraded
+                  properties:
+                    options:
+                      description: Options can be used to change the default behaviour
+                        of upgrade
+                      properties:
+                        ignoreStepsOnError:
+                          description: IgnoreStepsOnError allows to ignore steps which
+                            failed
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    pvName:
+                      description: PVName contains the name of the pv associated with
+                        the cstor volume
+                      type: string
+                  type: object
+                fromVersion:
+                  description: FromVersion is the current version of the resource.
+                  type: string
+                imagePrefix:
+                  description: ImagePrefix contains the url prefix of the image url.
+                    This field is optional. If not present upgrade takes the previously
+                    present ImagePrefix.
+                  type: string
+                imageTag:
+                  description: ImageTag contains the customized tag for ToVersion if
+                    any. This field is optional. If not present upgrade takes the ToVersion
+                    as the ImageTag
+                  type: string
+                jivaVolume:
+                  description: JivaVolume contains the details of the jiva volume to
+                    be upgraded
+                  properties:
+                    options:
+                      description: Options can be used to change the default behaviour
+                        of upgrade
+                      properties:
+                        ignoreStepsOnError:
+                          description: IgnoreStepsOnError allows to ignore steps which
+                            failed
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    pvName:
+                      description: PVName contains the name of the pv associated with
+                        the jiva volume
+                      type: string
+                  type: object
+                options:
+                  description: Options contains the optional flags that can be passed
+                    during upgrade.
+                  properties:
+                    timeout:
+                      description: Timeout is maximum seconds to wait at any given step
+                        in the upgrade
+                      type: integer
+                  type: object
+                storagePoolClaim:
+                  description: StoragePoolClaim contains the details of the storage
+                    pool claim to be upgraded
+                  properties:
+                    options:
+                      description: Options can be used to change the default behaviour
+                        of upgrade
+                      properties:
+                        ignoreStepsOnError:
+                          description: IgnoreStepsOnError allows to ignore steps which
+                            failed
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    spcName:
+                      description: SPCName contains the name of the storage pool claim
+                        to be upgraded
+                      type: string
+                  type: object
+                toVersion:
+                  description: ToVersion is the upgraded version of the resource. It
+                    should be same as the version of control plane components version.
+                  type: string
+              required:
+                - fromVersion
+                - toVersion
+              type: object
+            status:
+              description: Status of UpgradeTask
+              properties:
+                completedTime:
+                  description: CompletedTime of Upgrade
+                  format: date-time
+                  nullable: true
+                  type: string
+                phase:
+                  description: Phase indicates if a upgradeTask is started, success
+                    or errored
+                  type: string
+                retries:
+                  description: Retries is the number of times the job attempted to upgrade
+                    the resource
+                  type: integer
+                startTime:
+                  description: StartTime of Upgrade
+                  format: date-time
+                  nullable: true
+                  type: string
+                upgradeDetailedStatuses:
+                  description: UpgradeDetailedStatuses contains the list of statuses
+                    of each step
+                  items:
+                    description: UpgradeDetailedStatuses represents the latest available
+                      observations of a UpgradeTask current state.
+                    properties:
+                      lastUpdatedAt:
+                        description: LastUpdatedTime of a UpgradeStep
+                        format: date-time
+                        nullable: true
+                        type: string
+                      message:
+                        description: A human-readable message indicating details about
+                          why the upgradeStep is in this state
+                        type: string
+                      phase:
+                        description: Phase indicates if the UpgradeStep is waiting,
+                          errored or completed.
+                        type: string
+                      reason:
+                        description: Reason is a brief CamelCase string that describes
+                          any failure and is meant for machine parsing and tidy display
+                          in the CLI
+                        type: string
+                      startTime:
+                        description: StartTime of a UpgradeStep
+                        format: date-time
+                        nullable: true
+                        type: string
+                      step:
+                        description: UpgradeStep is the current step being performed
+                          for a particular resource upgrade
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: migrationtasks.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: MigrationTask
+    listKind: MigrationTaskList
+    plural: migrationtasks
+    shortNames:
+      - mtask
+    singular: migrationtask
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: MigrationTask represents an migration task
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec i.e. specifications of the MigrationTask
+              properties:
+                cstorPool:
+                  description: MigrateCStorPool contains the details of the cstor pool
+                    to be migrated
+                  properties:
+                    rename:
+                      description: If a CSPC with the same name as SPC already exists
+                        then we can rename SPC during migration using Rename
+                      type: string
+                    spcName:
+                      description: SPCName contains the name of the storage pool claim
+                        to be migrated
+                      type: string
+                  type: object
+                cstorVolume:
+                  description: MigrateCStorVolume contains the details of the cstor
+                    volume to be migrated
+                  properties:
+                    pvName:
+                      description: PVName contains the name of the pv associated with
+                        the cstor volume to be migrated
+                      type: string
+                  type: object
+              type: object
+            status:
+              description: Status of MigrationTask
+              properties:
+                completedTime:
+                  description: CompletedTime of Migrate
+                  format: date-time
+                  nullable: true
+                  type: string
+                migrationDetailedStatuses:
+                  description: MigrationDetailedStatuses contains the list of statuses
+                    of each step
+                  items:
+                    description: MigrationDetailedStatuses represents the latest available
+                      observations of a MigrationTask current state.
+                    properties:
+                      lastUpdatedAt:
+                        description: LastUpdatedTime of a MigrateStep
+                        format: date-time
+                        nullable: true
+                        type: string
+                      message:
+                        description: A human-readable message indicating details about
+                          why the migrationStep is in this state
+                        type: string
+                      phase:
+                        description: Phase indicates if the MigrateStep is waiting,
+                          errored or completed.
+                        type: string
+                      reason:
+                        description: Reason is a brief CamelCase string that describes
+                          any failure and is meant for machine parsing and tidy display
+                          in the CLI
+                        type: string
+                      startTime:
+                        description: StartTime of a MigrateStep
+                        format: date-time
+                        nullable: true
+                        type: string
+                      step:
+                        type: string
+                    type: object
+                  type: array
+                phase:
+                  description: Phase indicates if a migrationTask is started, success
+                    or errored
+                  type: string
+                retries:
+                  description: Retries is the number of times the job attempted to migration
+                    the resource
+                  type: integer
+                startTime:
+                  description: StartTime of Migrate
+                  format: date-time
+                  nullable: true
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cspc-operator
+  namespace: openebs
+  labels:
+    name: cspc-operator
+    openebs.io/component-name: cspc-operator
+    openebs.io/version: 2.8.0
+spec:
+  selector:
+    matchLabels:
+      name: cspc-operator
+      openebs.io/component-name: cspc-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: cspc-operator
+        openebs.io/component-name: cspc-operator
+        openebs.io/version: 2.8.0
+    spec:
+      serviceAccountName: openebs-cstor-operator
+      containers:
+        - name: cspc-operator
+          imagePullPolicy: IfNotPresent
+          image: openebs/cspc-operator:2.8.0
+          env:
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPENEBS_SERVICEACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: CSPC_OPERATOR_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+            # Where OpenEBS can store required files. Default base path will be /var/openebs
+            # - name: OPENEBS_IO_BASE_DIR
+            #   value: "/var/openebs"
+            # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath
+            # to be used for saving the shared content between the side cars
+            # of cstor pool pod. This ENV is also used to indicate the location
+            # of the sparse devices.
+            # The default path used is /var/openebs/sparse
+            #- name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+            #  value: "/var/openebs/sparse"
+            # OPENEBS_IO_IMAGE_PULL_SECRETS is used to specify the image pull secrets for the cstor pool pod
+            #- name: OPENEBS_IO_IMAGE_PULL_SECRETS
+            #  value: ""
+            - name: OPENEBS_IO_CSPI_MGMT_IMAGE
+              value: "openebs/cstor-pool-manager:2.8.0"
+            - name: OPENEBS_IO_CSTOR_POOL_IMAGE
+              value: "openebs/cstor-pool:2.8.0"
+            - name:  OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
+              value: "openebs/m-exporter:2.8.0"
+            - name: RESYNC_INTERVAL
+              value: "30"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cvc-operator
+  namespace: openebs
+  labels:
+    name: cvc-operator
+    openebs.io/component-name: cvc-operator
+    openebs.io/version: 2.8.0
+spec:
+  selector:
+    matchLabels:
+      name: cvc-operator
+      openebs.io/component-name: cvc-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: cvc-operator
+        openebs.io/component-name: cvc-operator
+        openebs.io/version: 2.8.0
+    spec:
+      serviceAccountName: openebs-cstor-operator
+      containers:
+        - name: cvc-operator
+          imagePullPolicy: IfNotPresent
+          image: openebs/cvc-operator:2.8.0
+          env:
+            # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+            # Where OpenEBS can store required files. Default base path will be /var/openebs
+            # - name: OPENEBS_IO_BASE_DIR
+            #   value: "/var/openebs"
+            # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
+            # that to be used for saving the core dump of cstor volume pod.
+            # The default path used is /var/openebs/sparse
+            #- name: OPENEBS_IO_CSTOR_TARGET_DIR
+            #  value: "/var/openebs/sparse"
+            # OPENEBS_IO_IMAGE_PULL_SECRETS is used to specify the image pull secrets for the cstor target pod
+            #- name: OPENEBS_IO_IMAGE_PULL_SECRETS
+            #  value: ""
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPENEBS_SERVICEACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
+              value: "openebs/cstor-istgt:2.8.0"
+            - name:  OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
+              value: "openebs/cstor-volume-manager:2.8.0"
+            - name:  OPENEBS_IO_VOLUME_MONITOR_IMAGE
+              value: "openebs/m-exporter:2.8.0"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cvc-operator-service
+  namespace: openebs
+  labels:
+    openebs.io/component-name: cvc-operator-svc
+spec:
+  ports:
+    - name: api
+      port: 5757
+      protocol: TCP
+      targetPort: 5757
+  selector:
+    name: cvc-operator
+  sessionAffinity: None
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-cstor-admission-server
+  namespace: openebs
+  labels:
+    app: cstor-admission-webhook
+    openebs.io/component-name: cstor-admission-webhook
+    openebs.io/version: 2.8.0
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  selector:
+    matchLabels:
+      app: cstor-admission-webhook
+  template:
+    metadata:
+      labels:
+        app: cstor-admission-webhook
+        openebs.io/component-name: cstor-admission-webhook
+        openebs.io/version: 2.8.0
+    spec:
+      serviceAccountName: openebs-cstor-operator
+      containers:
+        - name: admission-webhook
+          image: openebs/cstor-webhook:2.8.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - -alsologtostderr
+            - -v=2
+            - 2>&1
+          env:
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ADMISSION_WEBHOOK_NAME
+              value: "openebs-cstor-admission-server"
+            - name: ADMISSION_WEBHOOK_FAILURE_POLICY
+              value: "Fail"
+---
+# This manifest deploys the OpenEBS CStor and CSI control plane components,
+# with associated CRs & RBAC rules. This manifest has been verified
+# only with different linux flavours and linux distros
+#
+# For supporting a differnet OS other than the above,
+# 1) Get the list of shared object files required for iscsiadm binary in that OS version.
+# 2) Check which files are already present in the cstor-csi-driver container present in csi node pod.
+# 3) Mount the required missing files inside the container.
+#
+####################################################
+###########                             ############
+###########  CSI Node and Driver CRDs   ############
+###########                             ############
+####################################################
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: cstorvolumeattachments.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolumeAttachment
+    listKind: CStorVolumeAttachmentList
+    plural: cstorvolumeattachments
+    shortNames:
+      - cva
+    singular: cstorvolumeattachment
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: CStorVolumeAttachment represents a CSI based volume
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CStorVolumeAttachmentSpec is the spec for a CStorVolume resource
+              properties:
+                iscsi:
+                  description: ISCSIInfo specific to ISCSI protocol, this is filled
+                    only if the volume type is iSCSI
+                  properties:
+                    iqn:
+                      description: Iqn of this volume
+                      type: string
+                    iscsiInterface:
+                      description: IscsiInterface of this volume
+                      type: string
+                    lun:
+                      description: 'Lun specify the lun number 0, 1.. on iSCSI Volume.
+                      (default: 0)'
+                      type: string
+                    targetPortal:
+                      description: TargetPortal holds the target portal of this volume
+                      type: string
+                  type: object
+                volume:
+                  description: Volume specific info
+                  properties:
+                    accessModes:
+                      description: AccessMode of a volume will hold the access mode
+                        of the volume
+                      items:
+                        type: string
+                      type: array
+                    accessType:
+                      description: AccessType of a volume will indicate if the volume
+                        will be used as a block device or mounted on a path
+                      type: string
+                    capacity:
+                      description: Capacity of the volume
+                      type: string
+                    devicePath:
+                      description: Device Path specifies the device path which is returned
+                        when the iSCSI login is successful
+                      type: string
+                    fsType:
+                      description: FSType of a volume will specify the format type -
+                        ext4(default), xfs of PV
+                      type: string
+                    mountOptions:
+                      description: MountOptions specifies the options with which mount
+                        needs to be attempted
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      description: Name of the CSI volume
+                      type: string
+                    ownerNodeID:
+                      description: OwnerNodeID is the Node ID which is also the owner
+                        of this Volume
+                      type: string
+                    readOnly:
+                      description: ReadOnly specifies if the volume needs to be mounted
+                        in ReadOnly mode
+                      type: boolean
+                    stagingTargetPath:
+                      description: StagingPath of the volume will hold the path on which
+                        the volume is mounted on that node
+                      type: string
+                    targetPath:
+                      description: TargetPath of the volume will hold the path on which
+                        the volume is bind mounted on that node
+                      type: string
+                  required:
+                    - name
+                    - ownerNodeID
+                  type: object
+              required:
+                - iscsi
+                - volume
+              type: object
+            status:
+              description: CStorVolumeAttachmentStatus status represents the current
+                mount status of the volume
+              type: string
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+##############################################
+###########                       ############
+###########   Snapshot CRDs       ############
+###########                       ############
+##############################################
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/419"
+  creationTimestamp: null
+  name: volumesnapshotclasses.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotClass
+    listKind: VolumeSnapshotClassList
+    plural: volumesnapshotclasses
+    singular: volumesnapshotclass
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .driver
+          name: Driver
+          type: string
+        - description: Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
+          jsonPath: .deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshotClass specifies parameters that a underlying storage system uses when creating a volume snapshot. A specific VolumeSnapshotClass is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses are non-namespaced
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            deletionPolicy:
+              description: deletionPolicy determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. Required.
+              enum:
+                - Delete
+                - Retain
+              type: string
+            driver:
+              description: driver is the name of the storage driver that handles this VolumeSnapshotClass. Required.
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            parameters:
+              additionalProperties:
+                type: string
+              description: parameters is a key-value map with storage driver specific parameters for creating snapshots. These values are opaque to Kubernetes.
+              type: object
+          required:
+            - deletionPolicy
+            - driver
+          type: object
+      served: true
+      storage: false
+      subresources: {}
+    - additionalPrinterColumns:
+        - jsonPath: .driver
+          name: Driver
+          type: string
+        - description: Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
+          jsonPath: .deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshotClass specifies parameters that a underlying storage system uses when creating a volume snapshot. A specific VolumeSnapshotClass is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses are non-namespaced
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            deletionPolicy:
+              description: deletionPolicy determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. Required.
+              enum:
+                - Delete
+                - Retain
+              type: string
+            driver:
+              description: driver is the name of the storage driver that handles this VolumeSnapshotClass. Required.
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            parameters:
+              additionalProperties:
+                type: string
+              description: parameters is a key-value map with storage driver specific parameters for creating snapshots. These values are opaque to Kubernetes.
+              type: object
+          required:
+            - deletionPolicy
+            - driver
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/419"
+  creationTimestamp: null
+  name: volumesnapshotcontents.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotContent
+    listKind: VolumeSnapshotContentList
+    plural: volumesnapshotcontents
+    singular: volumesnapshotcontent
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: Represents the complete size of the snapshot in bytes
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: integer
+        - description: Determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted.
+          jsonPath: .spec.deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - description: Name of the CSI driver used to create the physical snapshot on the underlying storage system.
+          jsonPath: .spec.driver
+          name: Driver
+          type: string
+        - description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: VolumeSnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+          jsonPath: .spec.volumeSnapshotRef.name
+          name: VolumeSnapshot
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshotContent represents the actual "on-disk" snapshot object in the underlying storage system
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            spec:
+              description: spec defines properties of a VolumeSnapshotContent created by the underlying storage system. Required.
+              properties:
+                deletionPolicy:
+                  description: deletionPolicy determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. For dynamically provisioned snapshots, this field will automatically be filled in by the CSI snapshotter sidecar with the "DeletionPolicy" field defined in the corresponding VolumeSnapshotClass. For pre-existing snapshots, users MUST specify this field when creating the  VolumeSnapshotContent object. Required.
+                  enum:
+                    - Delete
+                    - Retain
+                  type: string
+                driver:
+                  description: driver is the name of the CSI driver used to create the physical snapshot on the underlying storage system. This MUST be the same as the name returned by the CSI GetPluginName() call for that driver. Required.
+                  type: string
+                source:
+                  description: source specifies whether the snapshot is (or should be) dynamically provisioned or already exists, and just requires a Kubernetes object representation. This field is immutable after creation. Required.
+                  properties:
+                    snapshotHandle:
+                      description: snapshotHandle specifies the CSI "snapshot_id" of a pre-existing snapshot on the underlying storage system for which a Kubernetes object representation was (or should be) created. This field is immutable.
+                      type: string
+                    volumeHandle:
+                      description: volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot should be dynamically taken from. This field is immutable.
+                      type: string
+                  type: object
+                  oneOf:
+                    - required: ["snapshotHandle"]
+                    - required: ["volumeHandle"]
+                volumeSnapshotClassName:
+                  description: name of the VolumeSnapshotClass from which this snapshot was (or will be) created. Note that after provisioning, the VolumeSnapshotClass may be deleted or recreated with different set of values, and as such, should not be referenced post-snapshot creation.
+                  type: string
+                volumeSnapshotRef:
+                  description: volumeSnapshotRef specifies the VolumeSnapshot object to which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName field must reference to this VolumeSnapshotContent's name for the bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent object, name and namespace of the VolumeSnapshot object MUST be provided for binding to happen. This field is immutable after creation. Required.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+              required:
+                - deletionPolicy
+                - driver
+                - source
+                - volumeSnapshotRef
+              type: object
+            status:
+              description: status represents the current information of a snapshot.
+              properties:
+                creationTime:
+                  description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it indicates the creation time is unknown. The format of this field is a Unix nanoseconds time encoded as an int64. On Unix, the command `date +%s%N` returns the current time in nanoseconds since 1970-01-01 00:00:00 UTC.
+                  format: int64
+                  type: integer
+                error:
+                  description: error is the last observed error during snapshot creation, if any. Upon success after retry, this error field will be cleared.
+                  properties:
+                    message:
+                      description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
+                      type: string
+                    time:
+                      description: time is the timestamp when the error was encountered.
+                      format: date-time
+                      type: string
+                  type: object
+                readyToUse:
+                  description: readyToUse indicates if a snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
+                  type: boolean
+                restoreSize:
+                  description: restoreSize represents the complete size of the snapshot in bytes. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
+                  format: int64
+                  minimum: 0
+                  type: integer
+                snapshotHandle:
+                  description: snapshotHandle is the CSI "snapshot_id" of a snapshot on the underlying storage system. If not specified, it indicates that dynamic snapshot creation has either failed or it is still in progress.
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: Represents the complete size of the snapshot in bytes
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: integer
+        - description: Determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted.
+          jsonPath: .spec.deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - description: Name of the CSI driver used to create the physical snapshot on the underlying storage system.
+          jsonPath: .spec.driver
+          name: Driver
+          type: string
+        - description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: VolumeSnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+          jsonPath: .spec.volumeSnapshotRef.name
+          name: VolumeSnapshot
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshotContent represents the actual "on-disk" snapshot object in the underlying storage system
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            spec:
+              description: spec defines properties of a VolumeSnapshotContent created by the underlying storage system. Required.
+              properties:
+                deletionPolicy:
+                  description: deletionPolicy determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. For dynamically provisioned snapshots, this field will automatically be filled in by the CSI snapshotter sidecar with the "DeletionPolicy" field defined in the corresponding VolumeSnapshotClass. For pre-existing snapshots, users MUST specify this field when creating the  VolumeSnapshotContent object. Required.
+                  enum:
+                    - Delete
+                    - Retain
+                  type: string
+                driver:
+                  description: driver is the name of the CSI driver used to create the physical snapshot on the underlying storage system. This MUST be the same as the name returned by the CSI GetPluginName() call for that driver. Required.
+                  type: string
+                source:
+                  description: source specifies whether the snapshot is (or should be) dynamically provisioned or already exists, and just requires a Kubernetes object representation. This field is immutable after creation. Required.
+                  properties:
+                    snapshotHandle:
+                      description: snapshotHandle specifies the CSI "snapshot_id" of a pre-existing snapshot on the underlying storage system for which a Kubernetes object representation was (or should be) created. This field is immutable.
+                      type: string
+                    volumeHandle:
+                      description: volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot should be dynamically taken from. This field is immutable.
+                      type: string
+                  type: object
+                volumeSnapshotClassName:
+                  description: name of the VolumeSnapshotClass from which this snapshot was (or will be) created. Note that after provisioning, the VolumeSnapshotClass may be deleted or recreated with different set of values, and as such, should not be referenced post-snapshot creation.
+                  type: string
+                volumeSnapshotRef:
+                  description: volumeSnapshotRef specifies the VolumeSnapshot object to which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName field must reference to this VolumeSnapshotContent's name for the bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent object, name and namespace of the VolumeSnapshot object MUST be provided for binding to happen. This field is immutable after creation. Required.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+              required:
+                - deletionPolicy
+                - driver
+                - source
+                - volumeSnapshotRef
+              type: object
+            status:
+              description: status represents the current information of a snapshot.
+              properties:
+                creationTime:
+                  description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it indicates the creation time is unknown. The format of this field is a Unix nanoseconds time encoded as an int64. On Unix, the command `date +%s%N` returns the current time in nanoseconds since 1970-01-01 00:00:00 UTC.
+                  format: int64
+                  type: integer
+                error:
+                  description: error is the last observed error during snapshot creation, if any. Upon success after retry, this error field will be cleared.
+                  properties:
+                    message:
+                      description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
+                      type: string
+                    time:
+                      description: time is the timestamp when the error was encountered.
+                      format: date-time
+                      type: string
+                  type: object
+                readyToUse:
+                  description: readyToUse indicates if a snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
+                  type: boolean
+                restoreSize:
+                  description: restoreSize represents the complete size of the snapshot in bytes. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
+                  format: int64
+                  minimum: 0
+                  type: integer
+                snapshotHandle:
+                  description: snapshotHandle is the CSI "snapshot_id" of a snapshot on the underlying storage system. If not specified, it indicates that dynamic snapshot creation has either failed or it is still in progress.
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/419"
+  creationTimestamp: null
+  name: volumesnapshots.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshot
+    listKind: VolumeSnapshotList
+    plural: volumesnapshots
+    singular: volumesnapshot
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: If a new snapshot needs to be created, this contains the name of the source PVC from which this snapshot was (or will be) created.
+          jsonPath: .spec.source.persistentVolumeClaimName
+          name: SourcePVC
+          type: string
+        - description: If a snapshot already exists, this contains the name of the existing VolumeSnapshotContent object representing the existing snapshot.
+          jsonPath: .spec.source.volumeSnapshotContentName
+          name: SourceSnapshotContent
+          type: string
+        - description: Represents the minimum size of volume required to rehydrate from this snapshot.
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: string
+        - description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: SnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshotContent object to which the VolumeSnapshot object intends to bind to. Please note that verification of binding actually requires checking both VolumeSnapshot and VolumeSnapshotContent to ensure both are pointing at each other. Binding MUST be verified prior to usage of this object.
+          jsonPath: .status.boundVolumeSnapshotContentName
+          name: SnapshotContent
+          type: string
+        - description: Timestamp when the point-in-time snapshot was taken by the underlying storage system.
+          jsonPath: .status.creationTime
+          name: CreationTime
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshot is a user's request for either creating a point-in-time snapshot of a persistent volume, or binding to a pre-existing snapshot.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            spec:
+              description: 'spec defines the desired characteristics of a snapshot requested by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots Required.'
+              properties:
+                source:
+                  description: source specifies where a snapshot will be created from. This field is immutable after creation. Required.
+                  properties:
+                    persistentVolumeClaimName:
+                      description: persistentVolumeClaimName specifies the name of the PersistentVolumeClaim object representing the volume from which a snapshot should be created. This PVC is assumed to be in the same namespace as the VolumeSnapshot object. This field should be set if the snapshot does not exists, and needs to be created. This field is immutable.
+                      type: string
+                    volumeSnapshotContentName:
+                      description: volumeSnapshotContentName specifies the name of a pre-existing VolumeSnapshotContent object representing an existing volume snapshot. This field should be set if the snapshot already exists and only needs a representation in Kubernetes. This field is immutable.
+                      type: string
+                  type: object
+                  oneOf:
+                    - required: ["persistentVolumeClaimName"]
+                    - required: ["volumeSnapshotContentName"]
+                volumeSnapshotClassName:
+                  description: 'VolumeSnapshotClassName is the name of the VolumeSnapshotClass requested by the VolumeSnapshot. VolumeSnapshotClassName may be left nil to indicate that the default SnapshotClass should be used. A given cluster may have multiple default Volume SnapshotClasses: one default per CSI Driver. If a VolumeSnapshot does not specify a SnapshotClass, VolumeSnapshotSource will be checked to figure out what the associated CSI Driver is, and the default VolumeSnapshotClass associated with that CSI Driver will be used. If more than one VolumeSnapshotClass exist for a given CSI Driver and more than one have been marked as default, CreateSnapshot will fail and generate an event. Empty string is not allowed for this field.'
+                  type: string
+              required:
+                - source
+              type: object
+            status:
+              description: status represents the current information of a snapshot. Consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.
+              properties:
+                boundVolumeSnapshotContentName:
+                  description: 'boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent object to which this VolumeSnapshot object intends to bind to. If not specified, it indicates that the VolumeSnapshot object has not been successfully bound to a VolumeSnapshotContent object yet. NOTE: To avoid possible security issues, consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.'
+                  type: string
+                creationTime:
+                  description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it may indicate that the creation time of the snapshot is unknown.
+                  format: date-time
+                  type: string
+                error:
+                  description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurrs during the snapshot creation. Upon success, this error field will be cleared.
+                  properties:
+                    message:
+                      description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
+                      type: string
+                    time:
+                      description: time is the timestamp when the error was encountered.
+                      format: date-time
+                      type: string
+                  type: object
+                readyToUse:
+                  description: readyToUse indicates if the snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
+                  type: boolean
+                restoreSize:
+                  type: string
+                  description: restoreSize represents the minimum size of volume required to create a volume from this snapshot. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: If a new snapshot needs to be created, this contains the name of the source PVC from which this snapshot was (or will be) created.
+          jsonPath: .spec.source.persistentVolumeClaimName
+          name: SourcePVC
+          type: string
+        - description: If a snapshot already exists, this contains the name of the existing VolumeSnapshotContent object representing the existing snapshot.
+          jsonPath: .spec.source.volumeSnapshotContentName
+          name: SourceSnapshotContent
+          type: string
+        - description: Represents the minimum size of volume required to rehydrate from this snapshot.
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: string
+        - description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: SnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshotContent object to which the VolumeSnapshot object intends to bind to. Please note that verification of binding actually requires checking both VolumeSnapshot and VolumeSnapshotContent to ensure both are pointing at each other. Binding MUST be verified prior to usage of this object.
+          jsonPath: .status.boundVolumeSnapshotContentName
+          name: SnapshotContent
+          type: string
+        - description: Timestamp when the point-in-time snapshot was taken by the underlying storage system.
+          jsonPath: .status.creationTime
+          name: CreationTime
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshot is a user's request for either creating a point-in-time snapshot of a persistent volume, or binding to a pre-existing snapshot.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            spec:
+              description: 'spec defines the desired characteristics of a snapshot requested by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots Required.'
+              properties:
+                source:
+                  description: source specifies where a snapshot will be created from. This field is immutable after creation. Required.
+                  properties:
+                    persistentVolumeClaimName:
+                      description: persistentVolumeClaimName specifies the name of the PersistentVolumeClaim object representing the volume from which a snapshot should be created. This PVC is assumed to be in the same namespace as the VolumeSnapshot object. This field should be set if the snapshot does not exists, and needs to be created. This field is immutable.
+                      type: string
+                    volumeSnapshotContentName:
+                      description: volumeSnapshotContentName specifies the name of a pre-existing VolumeSnapshotContent object representing an existing volume snapshot. This field should be set if the snapshot already exists and only needs a representation in Kubernetes. This field is immutable.
+                      type: string
+                  type: object
+                volumeSnapshotClassName:
+                  description: 'VolumeSnapshotClassName is the name of the VolumeSnapshotClass requested by the VolumeSnapshot. VolumeSnapshotClassName may be left nil to indicate that the default SnapshotClass should be used. A given cluster may have multiple default Volume SnapshotClasses: one default per CSI Driver. If a VolumeSnapshot does not specify a SnapshotClass, VolumeSnapshotSource will be checked to figure out what the associated CSI Driver is, and the default VolumeSnapshotClass associated with that CSI Driver will be used. If more than one VolumeSnapshotClass exist for a given CSI Driver and more than one have been marked as default, CreateSnapshot will fail and generate an event. Empty string is not allowed for this field.'
+                  type: string
+              required:
+                - source
+              type: object
+            status:
+              description: status represents the current information of a snapshot. Consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.
+              properties:
+                boundVolumeSnapshotContentName:
+                  description: 'boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent object to which this VolumeSnapshot object intends to bind to. If not specified, it indicates that the VolumeSnapshot object has not been successfully bound to a VolumeSnapshotContent object yet. NOTE: To avoid possible security issues, consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.'
+                  type: string
+                creationTime:
+                  description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it may indicate that the creation time of the snapshot is unknown.
+                  format: date-time
+                  type: string
+                error:
+                  description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurrs during the snapshot creation. Upon success, this error field will be cleared.
+                  properties:
+                    message:
+                      description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
+                      type: string
+                    time:
+                      description: time is the timestamp when the error was encountered.
+                      format: date-time
+                      type: string
+                  type: object
+                readyToUse:
+                  description: readyToUse indicates if the snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
+                  type: boolean
+                restoreSize:
+                  type: string
+                  description: restoreSize represents the minimum size of volume required to create a volume from this snapshot. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: cstor.csi.openebs.io
+spec:
+  # Supports persistent inline volumes.
+  volumeLifecycleModes:
+    - Persistent
+    # Not yet supported but added just to support upgrade control plane seamlessly
+    - Ephemeral
+  # To determine at runtime which mode a volume uses, pod info and its
+  # "csi.storage.k8s.io/ephemeral" entry are needed.
+  podInfoOnMount: true
+  attachRequired: false
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: openebs-csi-controller-critical
+value: 900000000
+globalDefault: false
+description: "This priority class should be used for the CStor CSI driver controller deployment only."
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: openebs-csi-node-critical
+value: 900001000
+globalDefault: false
+description: "This priority class should be used for the CStor CSI driver node deployment only."
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-snapshotter-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-snapshotter-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete", "get", "update"]
+
+---
+##############################################
+###########                       ############
+###########   Controller plugin   ############
+###########                       ############
+##############################################
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: openebs-cstor-csi-controller-sa
+  namespace: openebs
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets","namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "services"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["*"]
+  - apiGroups: ["*"]
+    resources: ["cstorvolumeattachments", "cstorvolumes","cstorvolumeconfigs"]
+    verbs: ["*"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-provisioner-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: openebs-cstor-csi-controller
+  namespace: openebs
+  labels:
+    name: openebs-cstor-csi-controller
+    openebs.io/component-name: openebs-cstor-csi-controller
+    openebs.io/version: 2.8.0
+spec:
+  selector:
+    matchLabels:
+      app: openebs-cstor-csi-controller
+      role: openebs-cstor-csi
+      name: openebs-cstor-csi-controller
+      openebs.io/component-name: openebs-cstor-csi-controller
+  serviceName: "openebs-csi"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: openebs-cstor-csi-controller
+        role: openebs-cstor-csi
+        name: openebs-cstor-csi-controller
+        openebs.io/component-name: openebs-cstor-csi-controller
+        openebs.io/version: 2.8.0
+    spec:
+      priorityClassName: openebs-csi-controller-critical
+      serviceAccount: openebs-cstor-csi-controller-sa
+      containers:
+        - name: csi-resizer
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-snapshotter
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
+          args:
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: snapshot-controller
+          image: k8s.gcr.io/sig-storage/snapshot-controller:v3.0.3
+          args:
+            - "--v=5"
+            - "--leader-election=false"
+          imagePullPolicy: IfNotPresent
+        - name: csi-provisioner
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--feature-gates=Topology=true"
+            - "--extra-create-metadata=true"
+            - "--metrics-address=:22011"
+            - "--timeout=250s"
+            - "--default-fstype=ext4"
+          env:
+            - name: MY_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-attacher
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: cstor-csi-plugin
+          image: openebs/cstor-csi-driver:2.8.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: OPENEBS_CONTROLLER_DRIVER
+              value: controller
+            - name: OPENEBS_CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: OPENEBS_CSI_API_URL
+              value: https://openebs.io
+              # OpenEBS namespace where the openebs cstor operator components
+              # has been installed
+            - name: OPENEBS_NAMESPACE
+              value: openebs
+            - name: OPENEBS_IO_INSTALLER_TYPE
+              value: "cstor-operator"
+            - name: OPENEBS_IO_ENABLE_ANALYTICS
+              value: "true"
+          args :
+            - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
+            - "--url=$(OPENEBS_CSI_API_URL)"
+            - "--plugin=$(OPENEBS_CONTROLLER_DRIVER)"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+---
+
+############################## CSI- Attacher #######################
+# Attacher must be able to work with PVs, nodes and VolumeAttachments
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-attacher-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments", "csinodes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-attacher-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-attacher-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-cluster-registrar-role
+rules:
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "delete"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-cluster-registrar-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-cluster-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+########################################
+###########                 ############
+###########   Node plugin   ############
+###########                 ############
+########################################
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-cstor-csi-node-sa
+  namespace: openebs
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-registrar-role
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "nodes", "services"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: ["*"]
+    resources: ["cstorvolumeattachments", "cstorvolumes","cstorvolumeconfigs"]
+    verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-registrar-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-node-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: openebs-cstor-csi-iscsiadm
+  namespace: openebs
+data:
+  iscsiadm: |
+    #!/bin/sh
+    if [ -x /host/sbin/iscsiadm ]; then
+      chroot /host /sbin/iscsiadm "$@"
+    elif [ -x /host/usr/local/sbin/iscsiadm ]; then
+      chroot /host /usr/local/sbin/iscsiadm "$@"
+    elif [ -x /host/bin/iscsiadm ]; then
+      chroot /host /bin/iscsiadm "$@"
+    elif [ -x /host/usr/local/bin/iscsiadm ]; then
+      chroot /host /usr/local/bin/iscsiadm "$@"
+    else
+      chroot /host iscsiadm "$@"
+    fi
+---
+
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: openebs-cstor-csi-node
+  namespace: openebs
+  labels:
+    app: openebs-cstor-csi-node
+    name: openebs-cstor-csi-node
+    openebs.io/component-name: openebs-cstor-csi-node
+    openebs.io/version: 2.8.0
+spec:
+  selector:
+    matchLabels:
+      app: openebs-cstor-csi-node
+      role: openebs-cstor-csi
+      name: openebs-cstor-csi-node
+      openebs.io/component-name: openebs-cstor-csi-node
+  template:
+    metadata:
+      labels:
+        app: openebs-cstor-csi-node
+        role: openebs-cstor-csi
+        name: openebs-cstor-csi-node
+        openebs.io/component-name: openebs-cstor-csi-node
+        openebs.io/version: 2.8.0
+    spec:
+      priorityClassName: openebs-csi-node-critical
+      serviceAccount: openebs-cstor-csi-node-sa
+      hostNetwork: true
+      containers:
+        - name: csi-node-driver-registrar
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/cstor.csi.openebs.io /registration/cstor.csi.openebs.io-reg.sock"]
+          env:
+            - name: ADDRESS
+              value: /plugin/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/cstor.csi.openebs.io/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_DRIVER
+              value: openebs-cstor-csi
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: registration-dir
+              mountPath: /registration
+        - name: cstor-csi-plugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["CAP_MKNOD", "CAP_SYS_ADMIN", "SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: openebs/cstor-csi-driver:2.8.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--nodeid=$(OPENEBS_NODE_ID)"
+            - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
+            - "--url=$(OPENEBS_CSI_API_URL)"
+            - "--plugin=$(OPENEBS_NODE_DRIVER)"
+          env:
+            - name: OPENEBS_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OPENEBS_CSI_ENDPOINT
+              value: unix:///plugin/csi.sock
+            - name: OPENEBS_NODE_DRIVER
+              value: node
+            - name: OPENEBS_CSI_API_URL
+              value: https://openebs.io
+              # OpenEBS namespace where the openebs cstor operator components
+              # has been installed
+            - name: OPENEBS_NAMESPACE
+              value: openebs
+              # Enable/Disable auto-remount feature, when volumes
+              # recovers form the read-only state
+            - name: REMOUNT
+              value: "true"
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: device-dir
+              mountPath: /dev
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/
+              # needed so that any mounts setup inside this container are
+              # propagated back to the host machine.
+              mountPropagation: "Bidirectional"
+            - name: host-root
+              mountPath: /host
+              mountPropagation: "HostToContainer"
+            - name: chroot-iscsiadm
+              mountPath: /sbin/iscsiadm
+              subPath: iscsiadm
+      volumes:
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/cstor.csi.openebs.io/
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/
+            type: Directory
+        - name: chroot-iscsiadm
+          configMap:
+            defaultMode: 0555
+            name: openebs-cstor-csi-iscsiadm
+        - name: host-root
+          hostPath:
+            path: /
+            type: Directory
+---

--- a/types/key.go
+++ b/types/key.go
@@ -337,6 +337,8 @@ const (
 	OpenEBSVersion260 string = "2.6.0"
 	// OpenEBSVersion270 is the OpenEBS version 2.7.0
 	OpenEBSVersion270 string = "2.7.0"
+	// OpenEBSVersion280 is the OpenEBS version 2.8.0
+	OpenEBSVersion280 string = "2.8.0"
 
 	// OSImageUbuntu1804 is the OS Image value of a Node.
 	OSImageUbuntu1804 string = "Ubuntu 18.04"
@@ -358,6 +360,8 @@ const (
 
 	// OpenEBSMayaOperatorSANameKey is the name of OpenEBS service account.
 	OpenEBSMayaOperatorSANameKey string = "openebs-maya-operator"
+	// OpenEBSCstorOperatorSANameKey is the name of OpenEBS cstor service account.
+	OpenEBSCstorOperatorSANameKey string = "openebs-cstor-operator"
 	// OpenEBSMayaOperatorRoleNameKey is the name of OpenEBS cluster role.
 	OpenEBSMayaOperatorRoleNameKey string = "openebs-maya-operator"
 	// OpenEBSCstorOperatorRoleNameKey is the name of OpenEBS cluster role.
@@ -405,6 +409,9 @@ const (
 	// OpenEBSSAComponentNameLabelValue is the value of the component-name label
 	// of OpenEBS service account.
 	OpenEBSSAComponentNameLabelValue string = "openebs-maya-operator"
+	// OpenEBSCstorSAComponentNameLabelValue is the value of the component-name label
+	// of OpenEBS cstor service account.
+	OpenEBSCstorSAComponentNameLabelValue string = "openebs-cstor-operator"
 	// CStorCSICtrlSAComponentNameLabelValue is the value of the component-name label
 	// of OpenEBS CStor CSI controller service account.
 	CStorCSICtrlSAComponentNameLabelValue string = "cstor-csi-controller"

--- a/types/ndm.go
+++ b/types/ndm.go
@@ -58,6 +58,8 @@ const (
 	NDMVersion120 string = "1.2.0"
 	// NDMVersion130 is the NDM version 1.3.0
 	NDMVersion130 string = "1.3.0"
+	// NDMVersion140 is the NDM version 1.4.0
+	NDMVersion140 string = "1.4.0"
 	// DefaultNDMSparseSize is the default size for NDM Sparse
 	DefaultNDMSparseSize string = "10737418240"
 	// DefaultNDMSparseCount is the default count for NDM sparse


### PR DESCRIPTION
A sample yaml to install OpenEBS `2.8.0`:
```
apiVersion: dao.mayadata.io/v1alpha1
kind: OpenEBS
metadata:
  name: install-openebs-2.8.0
spec:
  imagePrefix: openebs
  version: 2.8.0
  ```
In this version, cstor csi driver has been upgraded to v1 version and all the CRD's & RBAC's have been upgrade to v1 version.

Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>